### PR TITLE
pallet-ethereum: Add missing features

### DIFF
--- a/frame/ethereum/Cargo.toml
+++ b/frame/ethereum/Cargo.toml
@@ -74,11 +74,14 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
 	"pallet-evm/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
 ]
 try-runtime = [
+	"fp-self-contained/try-runtime",
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"pallet-timestamp/try-runtime",
 	"pallet-evm/try-runtime",
+	"sp-runtime/try-runtime",
 ]
 forbid-evm-reentrancy = ["pallet-evm/forbid-evm-reentrancy"]


### PR DESCRIPTION
I am updating the Centrifuge chain to Polkadot 0.9.37 and I'm facing the following error which I believe is being caused due to these missing features on the `pallet-ethereum` cargo file.

The error is:

```
error[E0046]: not all trait items implemented, missing: `unchecked_into_checked_i_know_what_i_am_doing`
  --> /Users/n/.cargo/git/checkouts/frontier-6f1ff17f29a883b0/8e2ad96/primitives/self-contained/src/unchecked_extrinsic.rs:80:1
   |
80 | / impl<Address, AccountId, Call, Signature, Extra, Lookup> Checkable<Lookup>
81 | |     for UncheckedExtrinsic<Address, Call, Signature, Extra>
   | |___________________________________________________________^ missing `unchecked_into_checked_i_know_what_i_am_doing` in implementation
   |
   = help: implement the missing item: `fn unchecked_into_checked_i_know_what_i_am_doing(self, _: &Context) -> Result<<Self as Checkable<Context>>::Checked, TransactionValidityError> { todo!() }`

For more information about this error, try `rustc --explain E0046`.
error: could not compile `fp-self-contained` due to previous error
```