### PR TITLE
Adds pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+-   repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+    -   id: fmt
+    -   id: cargo-check
+    -   id: clippy
+        args: ['--features', 'try-runtime,runtime-benchmarks']


### PR DESCRIPTION
`pre-commit` is a tool to standardize the git pre-commit hook checks.

This configuration adds `fmt`, `check` and `clippy` checks for the rust code.

Please refer to [the quick start guide](https://pre-commit.com/).