### PR TITLE
Use previous block hash to compute tx effectiveGasPrice

### DIFF
--- a/client/rpc/src/eth/transaction.rs
+++ b/client/rpc/src/eth/transaction.rs
@@ -289,10 +289,15 @@ where
 					EthereumTransaction::EIP2930(t) => t.gas_price,
 					EthereumTransaction::EIP1559(t) => {
 						let parent_eth_hash = block.header.parent_hash;
-						let parent_substrate_hash = self
-							.block_info_by_eth_block_hash(parent_eth_hash)
-							.await?
-							.substrate_hash;
+						let parent_substrate_hash = frontier_backend_client::load_hash::<B, C>(
+							self.client.as_ref(),
+							self.backend.as_ref(),
+							parent_eth_hash,
+						)
+						.await
+						.map_err(|err| internal_err(format!("{:?}", err)))?
+						.ok_or(internal_err("Failed to retrieve substrate block hash"))
+						.map_err(|err| internal_err(format!("{:?}", err)))?;
 
 						self.client
 							.runtime_api()

--- a/client/rpc/src/eth/transaction.rs
+++ b/client/rpc/src/eth/transaction.rs
@@ -284,7 +284,6 @@ where
 				let mut cumulative_receipts = receipts;
 				cumulative_receipts.truncate((status.transaction_index + 1) as usize);
 				let transaction = block.transactions[index].clone();
-
 				let effective_gas_price = match transaction {
 					EthereumTransaction::Legacy(t) => t.gas_price,
 					EthereumTransaction::EIP2930(t) => t.gas_price,

--- a/client/rpc/src/eth/transaction.rs
+++ b/client/rpc/src/eth/transaction.rs
@@ -296,8 +296,7 @@ where
 						)
 						.await
 						.map_err(|err| internal_err(format!("{:?}", err)))?
-						.ok_or(internal_err("Failed to retrieve substrate block hash"))
-						.map_err(|err| internal_err(format!("{:?}", err)))?;
+						.ok_or(internal_err("Failed to retrieve substrate block hash"))?;
 
 						self.client
 							.runtime_api()

--- a/client/rpc/src/eth/transaction.rs
+++ b/client/rpc/src/eth/transaction.rs
@@ -296,7 +296,7 @@ where
 						)
 						.await
 						.map_err(|err| internal_err(format!("{:?}", err)))?
-						.ok_or(internal_err("Failed to retrieve substrate block hash"))?;
+						.ok_or(internal_err("Failed to retrieve substrate parent block hash"))?;
 
 						self.client
 							.runtime_api()


### PR DESCRIPTION
Related fix for: https://github.com/moonbeam-foundation/moonbeam/pull/2610, calling `gas_price` from the runtime API using the transaction's parent block when computing base fee.