### PR TITLE
fix dispatch error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5815,7 +5815,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.9.0)",
+ "sp-std 14.0.0 (git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-v1.7.2)",
 ]
 
 [[package]]

--- a/client/mapping-sync/src/kv/mod.rs
+++ b/client/mapping-sync/src/kv/mod.rs
@@ -187,11 +187,7 @@ where
 	}
 
 	let best_hash = client.info().best_hash;
-	if SyncStrategy::Parachain == strategy
-		&& !frontier_backend
-			.mapping()
-			.is_synced(&best_hash)?
-	{
+	if SyncStrategy::Parachain == strategy && !frontier_backend.mapping().is_synced(&best_hash)? {
 		// Add best block to current_syncing_tips
 		current_syncing_tips.push(best_hash);
 	}

--- a/client/rpc/src/eth/execute.rs
+++ b/client/rpc/src/eth/execute.rs
@@ -93,7 +93,6 @@ mod old_types {
 
 	#[derive(PartialEq, Eq, Clone, Copy, Encode, Decode, Debug)]
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-	#[cfg_attr(feature = "std", serde(untagged))]
 	pub enum DispatchErrorLegacy {
 		/// Some error occurred.
 		Other(
@@ -131,6 +130,7 @@ mod old_types {
 	/// Reason why a dispatch call failed.
 	#[derive(PartialEq, Eq, Clone, Copy, Encode, Decode, Debug)]
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+	#[cfg_attr(feature = "std", serde(untagged))]
 	pub enum DispatchError {
 		V1(DispatchErrorLegacy),
 		V2(sp_runtime::DispatchError),


### PR DESCRIPTION
The changes contained in https://github.com/paritytech/substrate/pull/10776 changed the serde encoding for variant `DispatchError::Module`. This PR adds a Legacy type, which is used when decoding the return type of `call` method in version 4 of EthereumRuntimeRPCApi.