### PR TITLE
Cancun support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2291,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.41.1"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#cfcc81a1e13f8d6c96b6c0c10015ebf5c85b253a"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#8ee491bde0378d154e95ab13b80b8b1b205c3f10"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -2311,7 +2311,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.41.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#cfcc81a1e13f8d6c96b6c0c10015ebf5c85b253a"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#8ee491bde0378d154e95ab13b80b8b1b205c3f10"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -2322,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.41.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#cfcc81a1e13f8d6c96b6c0c10015ebf5c85b253a"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#8ee491bde0378d154e95ab13b80b8b1b205c3f10"
 dependencies = [
  "environmental",
  "evm-core",
@@ -2333,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.41.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#cfcc81a1e13f8d6c96b6c0c10015ebf5c85b253a"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#8ee491bde0378d154e95ab13b80b8b1b205c3f10"
 dependencies = [
  "auto_impl",
  "environmental",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2291,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.41.1"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-v1.7.2#d8991ec727ad0fb64fe9957a3cd307387a6701e4"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#3a5847de924dee90179cd4cb540fd06995204fcd"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -2311,7 +2311,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.41.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-v1.7.2#d8991ec727ad0fb64fe9957a3cd307387a6701e4"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#3a5847de924dee90179cd4cb540fd06995204fcd"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -2322,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.41.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-v1.7.2#d8991ec727ad0fb64fe9957a3cd307387a6701e4"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#3a5847de924dee90179cd4cb540fd06995204fcd"
 dependencies = [
  "environmental",
  "evm-core",
@@ -2333,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.41.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-v1.7.2#d8991ec727ad0fb64fe9957a3cd307387a6701e4"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#3a5847de924dee90179cd4cb540fd06995204fcd"
 dependencies = [
  "auto_impl",
  "environmental",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2291,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.41.1"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#8ee491bde0378d154e95ab13b80b8b1b205c3f10"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-v1.7.2#84979790a742326880c9c418dabe0e9af496cd6a"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -2311,7 +2311,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.41.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#8ee491bde0378d154e95ab13b80b8b1b205c3f10"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-v1.7.2#84979790a742326880c9c418dabe0e9af496cd6a"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -2322,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.41.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#8ee491bde0378d154e95ab13b80b8b1b205c3f10"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-v1.7.2#84979790a742326880c9c418dabe0e9af496cd6a"
 dependencies = [
  "environmental",
  "evm-core",
@@ -2333,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.41.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#8ee491bde0378d154e95ab13b80b8b1b205c3f10"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-v1.7.2#84979790a742326880c9c418dabe0e9af496cd6a"
 dependencies = [
  "auto_impl",
  "environmental",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2291,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.41.1"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#3a5847de924dee90179cd4cb540fd06995204fcd"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#cfcc81a1e13f8d6c96b6c0c10015ebf5c85b253a"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -2311,7 +2311,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.41.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#3a5847de924dee90179cd4cb540fd06995204fcd"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#cfcc81a1e13f8d6c96b6c0c10015ebf5c85b253a"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -2322,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.41.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#3a5847de924dee90179cd4cb540fd06995204fcd"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#cfcc81a1e13f8d6c96b6c0c10015ebf5c85b253a"
 dependencies = [
  "environmental",
  "evm-core",
@@ -2333,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.41.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#3a5847de924dee90179cd4cb540fd06995204fcd"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=v0.4.1-cancun#cfcc81a1e13f8d6c96b6c0c10015ebf5c85b253a"
 dependencies = [
  "auto_impl",
  "environmental",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ derive_more = "0.99"
 environmental = { version = "1.1.4", default-features = false }
 ethereum = { version = "0.15.0", default-features = false }
 ethereum-types = { version = "0.14.1", default-features = false }
-evm = { git = "https://github.com/moonbeam-foundation/evm", branch = "moonbeam-polkadot-v1.7.2", default-features = false }
+evm = { git = "https://github.com/moonbeam-foundation/evm", branch = "v0.4.1-cancun", default-features = false }
 futures = "0.3.30"
 hash-db = { version = "0.16.0", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ derive_more = "0.99"
 environmental = { version = "1.1.4", default-features = false }
 ethereum = { version = "0.15.0", default-features = false }
 ethereum-types = { version = "0.14.1", default-features = false }
-evm = { git = "https://github.com/moonbeam-foundation/evm", branch = "v0.4.1-cancun", default-features = false }
+evm = { git = "https://github.com/moonbeam-foundation/evm", branch = "moonbeam-polkadot-v1.7.2", default-features = false }
 futures = "0.3.30"
 hash-db = { version = "0.16.0", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -75,7 +75,7 @@ use scale_info::TypeInfo;
 // Substrate
 use frame_support::{
 	dispatch::{DispatchResultWithPostInfo, Pays, PostDispatchInfo},
-	storage::{child::KillStorageResult, KeyPrefixIterator},
+	storage::KeyPrefixIterator,
 	traits::{
 		fungible::{Balanced, Credit, Debt},
 		tokens::{
@@ -821,32 +821,14 @@ impl<T: Config> Pallet<T> {
 	/// Remove an account.
 	pub fn remove_account(address: &H160) {
 		if <AccountCodes<T>>::contains_key(address) {
-			// Remember to call `dec_sufficients` when clearing Suicided.
-			<Suicided<T>>::insert(address, ());
-
-			// In theory, we can always have pre-EIP161 contracts, so we
-			// make sure the account nonce is at least one.
 			let account_id = T::AddressMapping::into_account_id(*address);
-			frame_system::Pallet::<T>::inc_account_nonce(&account_id);
+			let _ = frame_system::Pallet::<T>::dec_sufficients(&account_id);
 		}
 
 		<AccountCodes<T>>::remove(address);
 		<AccountCodesMetadata<T>>::remove(address);
-
-		if T::SuicideQuickClearLimit::get() > 0 {
-			#[allow(deprecated)]
-			let res = <AccountStorages<T>>::remove_prefix(address, Some(T::SuicideQuickClearLimit::get()));
-
-			match res {
-				KillStorageResult::AllRemoved(_) => {
-					<Suicided<T>>::remove(address);
-
-					let account_id = T::AddressMapping::into_account_id(*address);
-					let _ = frame_system::Pallet::<T>::dec_sufficients(&account_id);
-				}
-				KillStorageResult::SomeRemaining(_) => (),
-			}
-		}
+		#[allow(deprecated)]
+		let _ = <AccountStorages<T>>::remove_prefix(address, None);
 	}
 
 	/// Create an account.

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -185,7 +185,7 @@ pub mod pallet {
 
 		/// EVM config used in the module.
 		fn config() -> &'static EvmConfig {
-			&SHANGHAI_CONFIG
+			&CANCUN_CONFIG
 		}
 	}
 
@@ -792,7 +792,7 @@ impl<T: Config> GasWeightMapping for FixedGasWeightMapping<T> {
 	}
 }
 
-static SHANGHAI_CONFIG: EvmConfig = EvmConfig::shanghai();
+static CANCUN_CONFIG: EvmConfig = EvmConfig::cancun();
 
 impl<T: Config> Pallet<T> {
 	/// Check whether an account is empty.

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -827,8 +827,7 @@ impl<T: Config> Pallet<T> {
 
 		<AccountCodes<T>>::remove(address);
 		<AccountCodesMetadata<T>>::remove(address);
-		#[allow(deprecated)]
-		let _ = <AccountStorages<T>>::remove_prefix(address, None);
+		let _ = <AccountStorages<T>>::clear_prefix(address, u32::max_value(), None);
 	}
 
 	/// Create an account.

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -725,6 +725,7 @@ pub struct SubstrateStackState<'vicinity, 'config, T> {
 	vicinity: &'vicinity Vicinity,
 	substate: SubstrateStackSubstate<'config>,
 	original_storage: BTreeMap<(H160, H256), H256>,
+	transient_storage: BTreeMap<(H160, H256), H256>,
 	recorded: Recorded,
 	weight_info: Option<WeightInfo>,
 	storage_meter: Option<StorageMeter>,
@@ -750,6 +751,7 @@ impl<'vicinity, 'config, T: Config> SubstrateStackState<'vicinity, 'config, T> {
 			},
 			_marker: PhantomData,
 			original_storage: BTreeMap::new(),
+			transient_storage: BTreeMap::new(),
 			recorded: Default::default(),
 			weight_info,
 			storage_meter,
@@ -844,6 +846,13 @@ where
 		<AccountStorages<T>>::get(address, index)
 	}
 
+	fn transient_storage(&self, address: H160, index: H256) -> H256 {
+		self.transient_storage
+			.get(&(address, index))
+			.copied()
+			.unwrap_or_default()
+	}
+
 	fn original_storage(&self, address: H160, index: H256) -> Option<H256> {
 		Some(
 			self.original_storage
@@ -928,6 +937,10 @@ where
 			);
 			<AccountStorages<T>>::insert(address, index, value);
 		}
+	}
+
+	fn set_transient_storage(&mut self, address: H160, key: H256, value: H256) {
+		self.transient_storage.insert((address, key), value);
 	}
 
 	fn reset_storage(&mut self, address: H160) {

--- a/frame/evm/src/tests.rs
+++ b/frame/evm/src/tests.rs
@@ -1269,7 +1269,7 @@ fn handle_sufficient_reference() {
 		assert_eq!(account_2.sufficients, 1);
 		EVM::remove_account(&addr_2);
 		let account_2 = frame_system::Account::<Test>::get(substrate_addr_2);
-		assert_eq!(account_2.sufficients, 1);
+		assert_eq!(account_2.sufficients, 0);
 	});
 }
 

--- a/precompiles/src/testing/handle.rs
+++ b/precompiles/src/testing/handle.rs
@@ -118,7 +118,7 @@ impl PrecompileHandle for MockHandle {
 		if self
 			.record_cost(crate::evm::costs::call_cost(
 				context.apparent_value,
-				&evm::Config::london(),
+				&evm::Config::cancun(),
 			))
 			.is_err()
 		{

--- a/primitives/evm/src/validation.rs
+++ b/primitives/evm/src/validation.rs
@@ -271,7 +271,7 @@ mod tests {
 		UnknownError,
 	}
 
-	static SHANGHAI_CONFIG: evm::Config = evm::Config::shanghai();
+	static CANCUN_CONFIG: evm::Config = evm::Config::cancun();
 
 	impl From<TransactionValidationError> for TestError {
 		fn from(e: TransactionValidationError) -> Self {
@@ -345,7 +345,7 @@ mod tests {
 		} = input;
 		CheckEvmTransaction::<TestError>::new(
 			CheckEvmTransactionConfig {
-				evm_config: &SHANGHAI_CONFIG,
+				evm_config: &CANCUN_CONFIG,
 				block_gas_limit: blockchain_gas_limit,
 				base_fee: blockchain_base_fee,
 				chain_id: blockchain_chain_id,

--- a/ts-tests/contracts/eip1153.sol
+++ b/ts-tests/contracts/eip1153.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+contract ReentrancyProtected {
+    // A constant key for the reentrancy guard stored in Transient Storage.
+    // This acts as a unique identifier for the reentrancy lock.
+    bytes32 constant REENTRANCY_GUARD = keccak256("REENTRANCY_GUARD");
+
+    // Modifier to prevent reentrant calls.
+    // It checks if the reentrancy guard is set (indicating an ongoing execution)
+    // and sets the guard before proceeding with the function execution.
+    // After the function executes, it resets the guard to allow future calls.
+    modifier nonReentrant() {
+        // Ensure the guard is not set (i.e., no ongoing execution).
+        require(tload(REENTRANCY_GUARD) == 0, "Reentrant call detected.");
+
+        // Set the guard to block reentrant calls.
+        tstore(REENTRANCY_GUARD, 1);
+
+        _; // Execute the function body.
+
+        // Reset the guard after execution to allow future calls.
+        tstore(REENTRANCY_GUARD, 0);
+    }
+
+    // Uses inline assembly to access the Transient Storage's tstore operation.
+    function tstore(bytes32 location, uint value) private {
+        assembly {
+            tstore(location, value)
+        }
+    }
+
+    // Uses inline assembly to access the Transient Storage's tload operation.
+    // Returns the value stored at the given location.
+    function tload(bytes32 location) private returns (uint value) {
+        assembly {
+            value := tload(location)
+        }
+    }
+
+    function nonReentrantMethod() public nonReentrant() {
+        (bool success, bytes memory result) = msg.sender.call("");
+        if (!success) {
+            assembly {
+                revert(add(32, result), mload(result))
+            }
+        }
+    }
+    
+    function test() external {
+        this.nonReentrantMethod();
+    }  
+
+    receive() external payable {
+        this.nonReentrantMethod();
+    }   
+}

--- a/ts-tests/package.json
+++ b/ts-tests/package.json
@@ -7,7 +7,7 @@
     "fmt-check": "prettier ./tests --check",
     "fmt": "prettier ./tests --write",
     "build": "truffle compile",
-    "test": "mocha -r ts-node/register 'tests/**/*.ts'",
+    "test": "mocha -r ts-node/register 'tests/test-eip1153.ts'",
     "test-sql": "FRONTIER_BACKEND_TYPE='sql' mocha -r ts-node/register 'tests/**/*.ts'"
   },
   "author": "",

--- a/ts-tests/tests/test-eip1153.ts
+++ b/ts-tests/tests/test-eip1153.ts
@@ -1,0 +1,54 @@
+import { expect, use as chaiUse } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { AbiItem } from "web3-utils";
+
+import ReentrancyProtected from "../build/contracts/ReentrancyProtected.json";
+import { GENESIS_ACCOUNT, GENESIS_ACCOUNT_PRIVATE_KEY } from "./config";
+import { createAndFinalizeBlock, customRequest, describeWithFrontier } from "./util";
+
+chaiUse(chaiAsPromised);
+
+describeWithFrontier("Frontier RPC (EIP-1153)", (context) => {
+	const TEST_CONTRACT_BYTECODE = ReentrancyProtected.bytecode;
+	const TEST_CONTRACT_ABI = ReentrancyProtected.abi as AbiItem[];
+	let contract_address: string = null;
+
+	// Those test are ordered. In general this should be avoided, but due to the time it takes
+	// to spin up a frontier node, it saves a lot of time.
+
+	before("create the contract", async function () {
+		this.timeout(15000);
+		const tx = await context.web3.eth.accounts.signTransaction(
+			{
+				from: GENESIS_ACCOUNT,
+				data: TEST_CONTRACT_BYTECODE,
+				value: "0x00",
+				gasPrice: "0x3B9ACA00",
+				gas: "0x100000",
+			},
+			GENESIS_ACCOUNT_PRIVATE_KEY
+		);
+		await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
+		await createAndFinalizeBlock(context.web3);
+
+		const receipt = await context.web3.eth.getTransactionReceipt(tx.transactionHash);
+		contract_address = receipt.contractAddress;
+	});
+
+	it("should detect reentrant call and revert", async function () {
+		const contract = new context.web3.eth.Contract(TEST_CONTRACT_ABI, contract_address, {
+			from: GENESIS_ACCOUNT,
+			gasPrice: "0x3B9ACA00"
+		});
+
+		try {
+			await contract.methods.test().call();
+		} catch (error) {
+			return expect(error.message).to.be.eq(
+				"Returned error: VM Exception while processing transaction: revert Reentrant call detected."
+			);
+		}
+
+		expect.fail("Expected the contract call to fail");
+	});
+});

--- a/ts-tests/truffle-config.js
+++ b/ts-tests/truffle-config.js
@@ -85,7 +85,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.8.2",    // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.8.25",    // Fetch exact version from solc-bin (default: truffle's version)
       docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {


### PR DESCRIPTION
- [x] Adds 2 new opcodes (`TLOAD` and `TSTORE`) for manipulating state that behaves almost identically to storage but is discarded after every transaction.

    - These new instructions were introduced by [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153) and included in Cancun fork.

- [x] Adds a new opcode  (`MCOPY`) for copying memory. Implementing this change will be important in ensuring that the same solidity/vyper contract compiles down to the same bytecode.´
   - This new instruction was introduced by [EIP-5656](https://eips.ethereum.org/EIPS/eip-5656) and included in Cancun fork.

- [x] Changes the behaviour of the self destruct opcode.
   - [EIP-6780: SELFDESTRUCT only in same transaction](https://eips.ethereum.org/EIPS/eip-6780)

