### PR TITLE
Expose last synced block to the backend api

### DIFF
--- a/client/api/src/backend.rs
+++ b/client/api/src/backend.rs
@@ -19,7 +19,7 @@
 use scale_codec::{Decode, Encode};
 // Substrate
 use sp_core::{H160, H256};
-use sp_runtime::traits::Block as BlockT;
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
 // Frontier
 use fp_storage::EthereumStorageSchema;
 
@@ -55,6 +55,9 @@ pub trait Backend<Block: BlockT>: Send + Sync {
 
 	/// Get the hash of the latest substrate block fully indexed by the backend.
 	async fn latest_block_hash(&self) -> Result<Block::Hash, String>;
+
+	/// Get the block number of the latest synced block.
+	async fn latest_synced_block(&self) -> Result<<Block::Header as HeaderT>::Number, String>;
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/client/db/src/kv/mod.rs
+++ b/client/db/src/kv/mod.rs
@@ -33,7 +33,8 @@ pub use sc_client_db::DatabaseSource;
 use sp_blockchain::HeaderBackend;
 use sp_core::{H160, H256};
 pub use sp_database::Database;
-use sp_runtime::traits::Block as BlockT;
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
+use sp_runtime::SaturatedConversion;
 // Frontier
 use fc_api::{FilteredLog, TransactionMetadata};
 use fp_storage::{EthereumStorageSchema, PALLET_ETHEREUM_SCHEMA_CACHE};
@@ -92,6 +93,10 @@ impl<Block: BlockT, C: HeaderBackend<Block>> fc_api::Backend<Block> for Backend<
 
 	async fn latest_block_hash(&self) -> Result<Block::Hash, String> {
 		Ok(self.client.info().best_hash)
+	}
+
+	async fn latest_synced_block(&self) -> Result<<Block::Header as HeaderT>::Number, String> {
+		Ok(self.client.info().finalized_number.saturated_into())
 	}
 }
 

--- a/client/db/src/sql/mod.rs
+++ b/client/db/src/sql/mod.rs
@@ -831,6 +831,17 @@ impl<Block: BlockT<Hash = H256>> fc_api::Backend<Block> for Backend<Block> {
 			.map(|row| H256::from_slice(&row.get::<Vec<u8>, _>(0)[..]))
 			.map_err(|e| format!("Failed to fetch best hash: {}", e))
 	}
+
+	async fn latest_synced_block(&self) -> Result<<Block::Header as HeaderT>::Number, String> {
+		sqlx::query("SELECT MAX(id) FROM sync_status")
+		.fetch_one(self.pool())
+		.await
+		.map(|row| {
+			let block_number: u32 = row.get(0);
+			return block_number.into()
+		})
+		.map_err(|e| format!("Failed to fetch block number: {}", e))
+	}
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
- Add an interface to get the last synced block from the database in the backend API
- Implement it for KV and SQL databases