### PR TITLE
EXTCODESIZE should read only once

### DIFF
--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -863,28 +863,17 @@ impl<T: Config> Pallet<T> {
 	/// Get the account metadata (hash and size) from storage if it exists,
 	/// or compute it from code and store it if it doesn't exist.
 	pub fn account_code_metadata(address: H160) -> CodeMetadata {
-		if let Some(meta) = <AccountCodesMetadata<T>>::get(address) {
-			return meta;
-		}
-
-		let code = <AccountCodes<T>>::get(address);
-
-		// If code is empty we return precomputed hash for empty code.
-		// We don't store it as this address could get code deployed in the future.
-		if code.is_empty() {
+		<AccountCodesMetadata<T>>::get(address).map_or(|| {
+			// If there is no codeMetadata, we assume that the code is empty,
+			// we then return precomputed hash for empty code.
 			const EMPTY_CODE_HASH: [u8; 32] = hex_literal::hex!(
 				"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
 			);
-			return CodeMetadata {
+			CodeMetadata {
 				size: 0,
 				hash: EMPTY_CODE_HASH.into(),
-			};
-		}
-
-		let meta = CodeMetadata::from_code(&code);
-
-		<AccountCodesMetadata<T>>::insert(address, meta);
-		meta
+			}
+		})
 	}
 
 	/// Get the account basic in EVM format.


### PR DESCRIPTION
The function account_code_metadata called by opcode EXTCODESIZE perform 2 reads if the contract doesn't exist, but we account only for 1 read.

this logic was there to migrate old contracts, we don't need it anymore