### PR TITLE
Re add code size check to runner

### DIFF
--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -50,7 +50,7 @@ use fp_evm::{
 use super::meter::StorageMeter;
 use crate::{
 	runner::Runner as RunnerT, AccountCodes, AccountCodesMetadata, AccountStorages, AddressMapping,
-	BalanceOf, BlockHashMapping, Config, Error, Event, FeeCalculator, OnChargeEVMTransaction,
+	BalanceOf, BlockHashMapping, CodeMetadata, Config, Error, Event, FeeCalculator, OnChargeEVMTransaction,
 	OnCreate, Pallet, RunnerError,
 };
 

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -214,10 +214,10 @@ where
 		//
 		// EIP-3607: https://eips.ethereum.org/EIPS/eip-3607
 		// Do not allow transactions for which `tx.sender` has any code deployed.
-		if is_transactional
-			&& !<AccountCodesMetadata<T>>::get(source)
-				.unwrap_or_default()
-				.size == 0
+		let metadata: CodeMetadata = <AccountCodesMetadata<T>>::get(source)
+			.unwrap_or_default();
+		let code: Vec<u8> = <AccountCodes<T>>::get(source);
+		if is_transactional && (metadata.size != 0 || !code.is_empty())
 		{
 			return Err(RunnerError {
 				error: Error::<T>::TransactionMustComeFromEOA,


### PR DESCRIPTION
When checking if a transaction comes from an EOA, besides checking the AccountCodesMetadata, check the AccountCodes code itself.