### PR TITLE
Allow to specify integer as `block_count` for `eth_feeHistory`

### DIFF
--- a/client/rpc-core/src/eth.rs
+++ b/client/rpc-core/src/eth.rs
@@ -214,7 +214,7 @@ pub trait EthApi {
 	#[method(name = "eth_feeHistory")]
 	async fn fee_history(
 		&self,
-		block_count: U256,
+		block_count: BlockCount,
 		newest_block: BlockNumberOrHash,
 		reward_percentiles: Option<Vec<f64>>,
 	) -> RpcResult<FeeHistory>;

--- a/client/rpc-core/src/types/block_count.rs
+++ b/client/rpc-core/src/types/block_count.rs
@@ -66,6 +66,15 @@ impl Into<U256> for BlockCount {
 	}
 }
 
+impl Into<u64> for BlockCount {
+    fn into(self) -> u64 {
+		match self {
+			BlockCount::U256(n) => n.as_u64(),
+			BlockCount::Num(n) => n
+		}
+	}
+}
+
 impl<'a> Visitor<'a> for BlockCountVisitor {
 	type Value = BlockCount;
 

--- a/client/rpc-core/src/types/block_count.rs
+++ b/client/rpc-core/src/types/block_count.rs
@@ -1,0 +1,129 @@
+// This file is part of Frontier.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{fmt, str::FromStr};
+use std::convert::Into;
+
+use ethereum_types::U256;
+use serde::{
+	de::{Error, Visitor},
+	Deserialize, Deserializer, Serialize, Serializer,
+};
+
+/// Represents An RPC Api block count param, which can take the form of a number, an hex string, or a 32-bytes array
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum BlockCount {
+	/// U256
+	U256(U256),
+	/// Number
+	Num(u64),
+}
+
+impl<'a> Deserialize<'a> for BlockCount {
+	fn deserialize<D>(deserializer: D) -> Result<BlockCount, D::Error>
+	where
+		D: Deserializer<'a>,
+	{
+		deserializer.deserialize_any(BlockCountVisitor)
+	}
+}
+
+impl Serialize for BlockCount {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		match *self {
+			BlockCount::U256(ref x) => x.serialize(serializer),
+			BlockCount::Num(ref x) => serializer.serialize_str(&format!("0x{:x}", x)),
+		}
+	}
+}
+
+struct BlockCountVisitor;
+
+impl Into<U256> for BlockCount {
+    fn into(self) -> U256 {
+		match self {
+			BlockCount::U256(n) => n,
+			BlockCount::Num(n) => U256::from(n)
+		}
+	}
+}
+
+impl<'a> Visitor<'a> for BlockCountVisitor {
+	type Value = BlockCount;
+
+	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+		write!(
+			formatter,
+			"an intenger, a (both 0x-prefixed or not) hex string or byte array containing between (0; 32] bytes"
+		)
+	}
+
+	fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		let number = value.parse::<u64>();
+		 match number {
+			Ok(n) => Ok(BlockCount::Num(n)),
+			Err(_) => U256::from_str(value)
+				.map(BlockCount::U256)
+				.map_err(|_| {
+					Error::custom(
+						"Invalid block count: non-decimal or missing 0x prefix".to_string()
+					)
+				})
+		} 
+	}
+
+	fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		self.visit_str(value.as_ref())
+	}
+
+	fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		Ok(BlockCount::Num(value))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	
+	fn match_block_number(block_count: BlockCount) -> Option<U256> {
+		match block_count {
+			BlockCount::Num(n) => Some(U256::from(n)),
+			BlockCount::U256(n) => Some(n),
+		}
+	}
+
+	#[test]
+	fn block_number_deserialize() {
+		let bn_dec: BlockCount = serde_json::from_str(r#""42""#).unwrap();
+		let bn_hex: BlockCount = serde_json::from_str(r#""0x45""#).unwrap();
+		assert_eq!(match_block_number(bn_dec).unwrap(), U256::from(42));
+		assert_eq!(match_block_number(bn_hex).unwrap(), U256::from("0x45"));
+	}
+}

--- a/client/rpc-core/src/types/mod.rs
+++ b/client/rpc-core/src/types/mod.rs
@@ -21,6 +21,7 @@
 mod account_info;
 mod block;
 mod block_number;
+mod block_count;
 mod bytes;
 mod call_request;
 mod fee;
@@ -46,6 +47,7 @@ pub use self::{
 	account_info::{AccountInfo, EthAccount, ExtAccountInfo, RecoveredAccount, StorageProof},
 	block::{Block, BlockTransactions, Header, Rich, RichBlock, RichHeader},
 	block_number::BlockNumberOrHash,
+	block_count::BlockCount,
 	bytes::Bytes,
 	call_request::CallStateOverride,
 	fee::{FeeHistory, FeeHistoryCache, FeeHistoryCacheItem, FeeHistoryCacheLimit},

--- a/client/rpc/src/eth/fee.rs
+++ b/client/rpc/src/eth/fee.rs
@@ -53,17 +53,13 @@ where
 
 	pub async fn fee_history(
 		&self,
-		block_count: U256,
+		block_count: u64,
 		newest_block: BlockNumberOrHash,
 		reward_percentiles: Option<Vec<f64>>,
 	) -> RpcResult<FeeHistory> {
 		// The max supported range size is 1024 by spec.
-		let range_limit = U256::from(1024);
-		let block_count = if block_count > range_limit {
-			range_limit.as_u64()
-		} else {
-			block_count.as_u64()
-		};
+		let range_limit: u64 = 1024;
+		let block_count: u64 = u64::min(block_count, range_limit);
 
 		if let Some(id) = frontier_backend_client::native_block_id::<B, C>(
 			self.client.as_ref(),

--- a/client/rpc/src/eth/mod.rs
+++ b/client/rpc/src/eth/mod.rs
@@ -494,11 +494,11 @@ where
 
 	async fn fee_history(
 		&self,
-		block_count: U256,
+		block_count: BlockCount,
 		newest_block: BlockNumberOrHash,
 		reward_percentiles: Option<Vec<f64>>,
 	) -> RpcResult<FeeHistory> {
-		self.fee_history(block_count, newest_block, reward_percentiles)
+		self.fee_history(block_count.into(), newest_block, reward_percentiles)
 			.await
 	}
 


### PR DESCRIPTION
## Motivation
As of now, `eth_feeHistory(block_count, newest_block, reward_percentiles)` allows to specify only `U256` values as `block_count`, this makes that some integrations doesn't behave as expected while passing an integer number of blocks, which is a valid use case.
Besides, the RPC call should be compatible with the following call (which succeds for Ethereum, but fails for, i.e. Moonbeam)
```

curl https://ethereum-sepolia-rpc.publicnode.com \
-X POST \
-H "Content-Type: application/json" \
--data '{"method":"eth_feeHistory","params":[10,"latest",[20.0]],"id":1,"jsonrpc":"2.0"}'

```