### PR TITLE
Refactor `fee_history` to make `block_count` an `u64`

### DIFF
--- a/client/rpc-core/src/eth.rs
+++ b/client/rpc-core/src/eth.rs
@@ -214,7 +214,7 @@ pub trait EthApi {
 	#[method(name = "eth_feeHistory")]
 	async fn fee_history(
 		&self,
-		block_count: U256,
+		block_count: u64,
 		newest_block: BlockNumberOrHash,
 		reward_percentiles: Option<Vec<f64>>,
 	) -> RpcResult<FeeHistory>;

--- a/client/rpc-v2/api/src/eth/mod.rs
+++ b/client/rpc-v2/api/src/eth/mod.rs
@@ -214,7 +214,7 @@ pub trait EthFeeMarketApi {
 	#[method(name = "feeHistory")]
 	async fn fee_history(
 		&self,
-		block_count: U256,
+		block_count: u64,
 		newest_block: BlockNumberOrTag,
 		reward_percentiles: Option<Vec<f64>>,
 	) -> RpcResult<FeeHistoryResult>;

--- a/client/rpc/src/eth/fee.rs
+++ b/client/rpc/src/eth/fee.rs
@@ -53,17 +53,13 @@ where
 
 	pub async fn fee_history(
 		&self,
-		block_count: U256,
+		block_count: u64,
 		newest_block: BlockNumberOrHash,
 		reward_percentiles: Option<Vec<f64>>,
 	) -> RpcResult<FeeHistory> {
 		// The max supported range size is 1024 by spec.
-		let range_limit = U256::from(1024);
-		let block_count = if block_count > range_limit {
-			range_limit.as_u64()
-		} else {
-			block_count.as_u64()
-		};
+		let range_limit: u64 = 1024;
+		let block_count: u64 = u64::min(block_count, range_limit);
 
 		if let Some(id) = frontier_backend_client::native_block_id::<B, C>(
 			self.client.as_ref(),

--- a/client/rpc/src/eth/mod.rs
+++ b/client/rpc/src/eth/mod.rs
@@ -494,7 +494,7 @@ where
 
 	async fn fee_history(
 		&self,
-		block_count: U256,
+		block_count: u64,
 		newest_block: BlockNumberOrHash,
 		reward_percentiles: Option<Vec<f64>>,
 	) -> RpcResult<FeeHistory> {


### PR DESCRIPTION
If we don't go ahead with #228 , here's a simpler solution with block count as u64. 
The spec says that the max value of `block_count` is 1024 anyway.