### PR TITLE
refund pov gas based on measured proof size usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,6 +722,7 @@ checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
+ "serde",
  "tap",
  "wyz",
 ]
@@ -1550,6 +1551,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher 0.4.4",
+]
+
+[[package]]
+name = "cumulus-primitives-core"
+version = "0.15.0"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
+dependencies = [
+ "parity-scale-codec",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
+ "scale-info",
+ "sp-api",
+ "sp-runtime",
+ "sp-trie",
+ "staging-xcm",
+]
+
+[[package]]
+name = "cumulus-primitives-proof-size-hostfunction"
+version = "0.10.0"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
+dependencies = [
+ "sp-externalities",
+ "sp-runtime-interface",
+ "sp-trie",
+]
+
+[[package]]
+name = "cumulus-primitives-storage-weight-reclaim"
+version = "7.0.0"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
+dependencies = [
+ "cumulus-primitives-core",
+ "cumulus-primitives-proof-size-hostfunction",
+ "docify",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -2584,7 +2627,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2714,7 +2757,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2738,7 +2781,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "42.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -2788,7 +2831,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -2818,7 +2861,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.5.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "array-bytes",
  "docify",
@@ -2833,7 +2876,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -2874,7 +2917,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "30.0.2"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2893,7 +2936,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
@@ -2905,7 +2948,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2915,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "cfg-if",
  "docify",
@@ -2935,7 +2978,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2949,7 +2992,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "34.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -2959,7 +3002,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5765,7 +5808,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-aura"
 version = "36.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5781,7 +5824,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5794,7 +5837,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5817,7 +5860,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "38.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5893,6 +5936,7 @@ dependencies = [
 name = "pallet-evm"
 version = "6.0.0-dev"
 dependencies = [
+ "cumulus-primitives-storage-weight-reclaim",
  "environmental",
  "evm",
  "fp-account",
@@ -6076,7 +6120,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6113,7 +6157,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6134,7 +6178,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6149,7 +6193,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "36.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6168,7 +6212,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6183,7 +6227,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -6199,7 +6243,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6211,7 +6255,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6500,6 +6544,59 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "polkadot-core-primitives"
+version = "15.0.0"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-runtime",
+]
+
+[[package]]
+name = "polkadot-parachain-primitives"
+version = "14.0.0"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
+dependencies = [
+ "bounded-collections",
+ "derive_more",
+ "parity-scale-codec",
+ "polkadot-core-primitives",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime",
+ "sp-weights",
+]
+
+[[package]]
+name = "polkadot-primitives"
+version = "15.0.0"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
+dependencies = [
+ "bitvec",
+ "hex-literal",
+ "log",
+ "parity-scale-codec",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-authority-discovery",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-staking",
+]
 
 [[package]]
 name = "polkavm"
@@ -7705,7 +7802,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "29.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "log",
  "sp-core",
@@ -7716,7 +7813,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.44.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7738,7 +7835,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.42.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7753,7 +7850,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "array-bytes",
  "docify",
@@ -7780,7 +7877,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -7791,7 +7888,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.46.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -7835,7 +7932,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "fnv",
  "futures",
@@ -7862,7 +7959,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.44.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -7888,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "async-trait",
  "futures",
@@ -7912,7 +8009,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.44.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "async-trait",
  "futures",
@@ -7941,7 +8038,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.44.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -7977,7 +8074,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -7990,7 +8087,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.29.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -8034,7 +8131,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.45.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -8069,7 +8166,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "async-trait",
  "futures",
@@ -8092,7 +8189,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.40.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8116,7 +8213,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.35.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "parity-scale-codec",
  "polkavm",
@@ -8130,7 +8227,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.32.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "log",
  "polkavm",
@@ -8141,7 +8238,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.35.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -8160,7 +8257,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "ansi_term",
  "futures",
@@ -8177,7 +8274,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "33.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -8191,7 +8288,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.14.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "array-bytes",
  "arrayvec",
@@ -8220,7 +8317,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.44.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -8271,7 +8368,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -8289,7 +8386,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.44.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "ahash",
  "futures",
@@ -8308,7 +8405,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -8329,7 +8426,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -8366,7 +8463,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "array-bytes",
  "futures",
@@ -8385,7 +8482,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.12.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "bs58 0.5.0",
  "ed25519-dalek",
@@ -8402,7 +8499,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -8436,7 +8533,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.18.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -8445,7 +8542,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -8477,7 +8574,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -8497,7 +8594,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "16.0.2"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "forwarded-header-value",
  "futures",
@@ -8519,7 +8616,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.44.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "array-bytes",
  "futures",
@@ -8551,7 +8648,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.45.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "async-trait",
  "directories",
@@ -8615,7 +8712,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.36.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8626,7 +8723,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "derive_more",
  "futures",
@@ -8647,7 +8744,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "24.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "chrono",
  "futures",
@@ -8667,7 +8764,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -8697,7 +8794,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -8708,7 +8805,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "async-trait",
  "futures",
@@ -8735,7 +8832,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "async-trait",
  "futures",
@@ -8751,7 +8848,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "17.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "async-channel",
  "futures",
@@ -9286,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "docify",
  "hash-db",
@@ -9308,7 +9405,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -9322,7 +9419,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9334,7 +9431,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -9346,9 +9443,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-authority-discovery"
+version = "34.0.0"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-runtime",
+]
+
+[[package]]
 name = "sp-block-builder"
 version = "34.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -9358,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -9377,7 +9486,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.40.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "async-trait",
  "futures",
@@ -9392,7 +9501,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.40.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9408,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.40.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9426,7 +9535,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "21.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -9443,7 +9552,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.40.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9454,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -9500,7 +9609,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -9513,7 +9622,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -9523,7 +9632,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -9532,7 +9641,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9542,7 +9651,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9552,7 +9661,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.15.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9564,7 +9673,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -9577,7 +9686,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "38.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "bytes",
  "docify",
@@ -9603,7 +9712,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -9613,7 +9722,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -9624,7 +9733,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -9633,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -9643,7 +9752,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.12.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9654,7 +9763,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "34.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -9664,7 +9773,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -9674,7 +9783,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "32.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -9684,7 +9793,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "docify",
  "either",
@@ -9710,7 +9819,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -9729,7 +9838,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "Inflector",
  "expander",
@@ -9742,7 +9851,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "35.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9756,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "34.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9769,7 +9878,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "hash-db",
  "log",
@@ -9789,7 +9898,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "18.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "aes-gcm 0.10.2",
  "curve25519-dalek",
@@ -9813,12 +9922,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9830,7 +9939,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9842,7 +9951,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -9853,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "34.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -9862,7 +9971,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "34.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9876,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "ahash",
  "hash-db",
@@ -9899,7 +10008,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9916,7 +10025,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -9927,7 +10036,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -9939,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -10129,7 +10238,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-xcm"
 version = "14.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -10248,7 +10357,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -10273,12 +10382,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "38.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -10298,7 +10407,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "http-body-util",
  "hyper 1.4.1",
@@ -10312,7 +10421,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -10339,7 +10448,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "array-bytes",
  "frame-executive",
@@ -10383,7 +10492,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "futures",
  "sc-block-builder",
@@ -10401,7 +10510,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "24.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -12031,7 +12140,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "10.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#5aae730607a9fde5471729f97dd03bde74499964"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2407#86b704de84221ef445b7422c1bbc7fcafb6b9e15"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,9 @@ substrate-frame-rpc-system = { git = "https://github.com/moonbeam-foundation/pol
 substrate-test-runtime-client = { git = "https://github.com/moonbeam-foundation/polkadot-sdk", branch = "moonbeam-polkadot-stable2407" }
 substrate-wasm-builder = { git = "https://github.com/moonbeam-foundation/polkadot-sdk", branch = "moonbeam-polkadot-stable2407" }
 
+# Cumulus primitives
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/moonbeam-foundation/polkadot-sdk", branch = "moonbeam-polkadot-stable2407", default-features = false }
+
 # XCM
 xcm = { package = "staging-xcm", git = "https://github.com/moonbeam-foundation/polkadot-sdk", branch = "moonbeam-polkadot-stable2407", default-features = false }
 

--- a/client/rpc-core/src/types/block_count.rs
+++ b/client/rpc-core/src/types/block_count.rs
@@ -16,8 +16,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{fmt, str::FromStr};
 use std::convert::Into;
+use std::{fmt, str::FromStr};
 
 use ethereum_types::U256;
 use serde::{
@@ -58,19 +58,19 @@ impl Serialize for BlockCount {
 struct BlockCountVisitor;
 
 impl Into<U256> for BlockCount {
-    fn into(self) -> U256 {
+	fn into(self) -> U256 {
 		match self {
 			BlockCount::U256(n) => n,
-			BlockCount::Num(n) => U256::from(n)
+			BlockCount::Num(n) => U256::from(n),
 		}
 	}
 }
 
 impl Into<u64> for BlockCount {
-    fn into(self) -> u64 {
+	fn into(self) -> u64 {
 		match self {
 			BlockCount::U256(n) => n.as_u64(),
-			BlockCount::Num(n) => n
+			BlockCount::Num(n) => n,
 		}
 	}
 }
@@ -90,16 +90,12 @@ impl<'a> Visitor<'a> for BlockCountVisitor {
 		E: Error,
 	{
 		let number = value.parse::<u64>();
-		 match number {
+		match number {
 			Ok(n) => Ok(BlockCount::Num(n)),
-			Err(_) => U256::from_str(value)
-				.map(BlockCount::U256)
-				.map_err(|_| {
-					Error::custom(
-						"Invalid block count: non-decimal or missing 0x prefix".to_string()
-					)
-				})
-		} 
+			Err(_) => U256::from_str(value).map(BlockCount::U256).map_err(|_| {
+				Error::custom("Invalid block count: non-decimal or missing 0x prefix".to_string())
+			}),
+		}
 	}
 
 	fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
@@ -120,7 +116,7 @@ impl<'a> Visitor<'a> for BlockCountVisitor {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	
+
 	fn match_block_number(block_count: BlockCount) -> Option<U256> {
 		match block_count {
 			BlockCount::Num(n) => Some(U256::from(n)),

--- a/client/rpc-core/src/types/mod.rs
+++ b/client/rpc-core/src/types/mod.rs
@@ -20,8 +20,8 @@
 
 mod account_info;
 mod block;
-mod block_number;
 mod block_count;
+mod block_number;
 mod bytes;
 mod call_request;
 mod fee;
@@ -46,8 +46,8 @@ pub use self::txpool::{Summary, TransactionMap, TxPoolResult};
 pub use self::{
 	account_info::{AccountInfo, EthAccount, ExtAccountInfo, RecoveredAccount, StorageProof},
 	block::{Block, BlockTransactions, Header, Rich, RichBlock, RichHeader},
-	block_number::BlockNumberOrHash,
 	block_count::BlockCount,
+	block_number::BlockNumberOrHash,
 	bytes::Bytes,
 	call_request::CallStateOverride,
 	fee::{FeeHistory, FeeHistoryCache, FeeHistoryCacheItem, FeeHistoryCacheLimit},

--- a/frame/ethereum/src/lib.rs
+++ b/frame/ethereum/src/lib.rs
@@ -34,12 +34,12 @@ mod mock;
 mod tests;
 
 use alloc::{vec, vec::Vec};
+pub use catch_exec_info::catch_exec_info;
 use core::marker::PhantomData;
 pub use ethereum::{
 	AccessListItem, BlockV2 as Block, LegacyTransactionMessage, Log, ReceiptV3 as Receipt,
 	TransactionAction, TransactionV2 as Transaction,
 };
-pub use catch_exec_info::catch_exec_info;
 
 use ethereum_types::{Bloom, BloomInput, H160, H256, H64, U256};
 use evm::ExitReason;
@@ -298,7 +298,8 @@ pub mod pallet {
 				"pre log already exists; block is invalid",
 			);
 
-			Self::apply_validated_transaction(source, transaction, None).map(|(post_info, _)| post_info)
+			Self::apply_validated_transaction(source, transaction, None)
+				.map(|(post_info, _)| post_info)
 		}
 	}
 
@@ -520,8 +521,7 @@ impl<T: Config> Pallet<T> {
 			.map_err(|e| e.0)?;
 
 		use pallet_evm::OnChargeEVMTransaction;
-		let max_withdraw = check_transaction.max_withdraw_amount()
-			.map_err(|e| e.0)?;
+		let max_withdraw = check_transaction.max_withdraw_amount().map_err(|e| e.0)?;
 		<T as pallet_evm::Config>::OnChargeTransaction::can_withdraw(&origin, max_withdraw)
 			.map_err(|_| InvalidTransaction::Payment)?;
 
@@ -929,8 +929,7 @@ impl<T: Config> Pallet<T> {
 			.map_err(|e| TransactionValidityError::Invalid(e.0))?;
 
 		use pallet_evm::OnChargeEVMTransaction;
-		let max_withdraw = check_transaction.max_withdraw_amount()
-			.map_err(|e| e.0)?;
+		let max_withdraw = check_transaction.max_withdraw_amount().map_err(|e| e.0)?;
 		<T as pallet_evm::Config>::OnChargeTransaction::can_withdraw(&origin, max_withdraw)
 			.map_err(|_| InvalidTransaction::Payment)?;
 

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -20,6 +20,10 @@ impl-trait-for-tuples = "0.2.2"
 log = { workspace = true }
 scale-codec = { package = "parity-scale-codec", workspace = true }
 scale-info = { workspace = true }
+
+# Cumulus
+cumulus-primitives-storage-weight-reclaim = { workspace = true, default-features = false }
+
 # Substrate
 frame-benchmarking = { workspace = true, optional = true }
 frame-support = { workspace = true }
@@ -27,6 +31,7 @@ frame-system = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
+
 # Frontier
 fp-account = { workspace = true }
 fp-evm = { workspace = true, features = ["serde"] }
@@ -48,6 +53,8 @@ std = [
 	"log/std",
 	"scale-codec/std",
 	"scale-info/std",
+	# Cumulus
+    "cumulus-primitives-storage-weight-reclaim/std",
 	# Substrate
 	"frame-benchmarking?/std",
 	"frame-support/std",

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -77,6 +77,7 @@ use impl_trait_for_tuples::impl_for_tuples;
 use scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 // Substrate
+use frame_support::traits::tokens::WithdrawConsequence;
 use frame_support::{
 	dispatch::{DispatchResultWithPostInfo, Pays, PostDispatchInfo},
 	storage::KeyPrefixIterator,
@@ -92,7 +93,6 @@ use frame_support::{
 	},
 	weights::Weight,
 };
-use frame_support::traits::tokens::WithdrawConsequence;
 use frame_system::RawOrigin;
 use sp_core::{H160, H256, U256};
 use sp_runtime::{

--- a/frame/evm/src/runner/meter.rs
+++ b/frame/evm/src/runner/meter.rs
@@ -16,13 +16,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use alloc::collections::btree_set::BTreeSet;
 use evm::{
 	gasometer::{GasCost, StorageTarget},
 	Opcode,
 };
 use fp_evm::ACCOUNT_STORAGE_PROOF_SIZE;
 use sp_core::{H160, H256};
-use alloc::collections::btree_set::BTreeSet;
 
 /// An error that is returned when the storage limit has been exceeded.
 #[derive(Debug, PartialEq)]

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -29,6 +29,8 @@ use evm::{
 	gasometer::{GasCost, StorageTarget},
 	ExitError, ExitReason, ExternalOperation, Opcode, Transfer,
 };
+// Cumulus
+use cumulus_primitives_storage_weight_reclaim::get_proof_size;
 // Substrate
 use frame_support::{
 	traits::{
@@ -79,6 +81,7 @@ where
 		is_transactional: bool,
 		weight_limit: Option<Weight>,
 		proof_size_base_cost: Option<u64>,
+		measured_proof_size_before: u64,
 		f: F,
 	) -> Result<ExecutionInfoV2<R>, RunnerError<Error<T>>>
 	where
@@ -109,6 +112,7 @@ where
 			weight,
 			weight_limit,
 			proof_size_base_cost,
+			measured_proof_size_before,
 		);
 
 		#[cfg(feature = "forbid-evm-reentrancy")]
@@ -147,6 +151,7 @@ where
 				weight,
 				weight_limit,
 				proof_size_base_cost,
+				measured_proof_size_before,
 			)
 		});
 
@@ -168,6 +173,7 @@ where
 		weight: Weight,
 		weight_limit: Option<Weight>,
 		proof_size_base_cost: Option<u64>,
+		measured_proof_size_before: u64,
 	) -> Result<ExecutionInfoV2<R>, RunnerError<Error<T>>>
 	where
 		F: FnOnce(
@@ -296,15 +302,23 @@ where
 					None => 0,
 				};
 
-				let pov_gas = match executor.state().weight_info() {
-					Some(weight_info) => weight_info
+				// Measure actual proof size usage (or get computed proof size)
+				let actual_proof_size = if let Some(measured_proof_size_after) = get_proof_size() {
+					measured_proof_size_after.saturating_sub(measured_proof_size_before)
+				} else {
+					executor
+						.state()
+						.weight_info()
+						.unwrap_or_default()
 						.proof_size_usage
 						.unwrap_or_default()
-						.saturating_mul(T::GasLimitPovSizeRatio::get()),
-					None => 0,
 				};
 
 				// Post execution.
+				let pov_gas = core::cmp::min(
+					actual_proof_size.saturating_mul(T::GasLimitPovSizeRatio::get()),
+					gas_limit,
+				);
 				let used_gas = executor.used_gas();
 				let effective_gas = U256::from(core::cmp::max(
 					core::cmp::max(used_gas, pov_gas),
@@ -477,6 +491,7 @@ where
 		proof_size_base_cost: Option<u64>,
 		config: &evm::Config,
 	) -> Result<CallInfo, RunnerError<Self::Error>> {
+		let measured_proof_size_before = get_proof_size().unwrap_or_default();
 		if validate {
 			Self::validate(
 				source,
@@ -506,6 +521,7 @@ where
 			is_transactional,
 			weight_limit,
 			proof_size_base_cost,
+			measured_proof_size_before,
 			|executor| executor.transact_call(source, target, value, input, gas_limit, access_list),
 		)
 	}
@@ -525,6 +541,7 @@ where
 		proof_size_base_cost: Option<u64>,
 		config: &evm::Config,
 	) -> Result<CreateInfo, RunnerError<Self::Error>> {
+		let measured_proof_size_before = get_proof_size().unwrap_or_default();
 		if validate {
 			Self::validate(
 				source,
@@ -554,6 +571,7 @@ where
 			is_transactional,
 			weight_limit,
 			proof_size_base_cost,
+			measured_proof_size_before,
 			|executor| {
 				let address = executor.create_address(evm::CreateScheme::Legacy { caller: source });
 				T::OnCreate::on_create(source, address);
@@ -580,6 +598,7 @@ where
 		proof_size_base_cost: Option<u64>,
 		config: &evm::Config,
 	) -> Result<CreateInfo, RunnerError<Self::Error>> {
+		let measured_proof_size_before = get_proof_size().unwrap_or_default();
 		if validate {
 			Self::validate(
 				source,
@@ -610,6 +629,7 @@ where
 			is_transactional,
 			weight_limit,
 			proof_size_base_cost,
+			measured_proof_size_before,
 			|executor| {
 				let address = executor.create_address(evm::CreateScheme::Create2 {
 					caller: source,
@@ -640,6 +660,7 @@ where
 		config: &evm::Config,
 		contract_address: H160,
 	) -> Result<CreateInfo, RunnerError<Self::Error>> {
+		let measured_proof_size_before = get_proof_size().unwrap_or_default();
 		if validate {
 			Self::validate(
 				source,
@@ -669,6 +690,7 @@ where
 			is_transactional,
 			weight_limit,
 			proof_size_base_cost,
+			measured_proof_size_before,
 			|executor| {
 				T::OnCreate::on_create(source, contract_address);
 				let (reason, _) = executor.transact_create_force_address(

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -624,7 +624,6 @@ where
 		)
 	}
 
-
 	fn create_force_address(
 		source: H160,
 		init: Vec<u8>,
@@ -672,8 +671,14 @@ where
 			proof_size_base_cost,
 			|executor| {
 				T::OnCreate::on_create(source, contract_address);
-				let (reason, _) =
-					executor.transact_create_force_address(source, value, init, gas_limit, access_list, contract_address);
+				let (reason, _) = executor.transact_create_force_address(
+					source,
+					value,
+					init,
+					gas_limit,
+					access_list,
+					contract_address,
+				);
 				(reason, contract_address)
 			},
 		)
@@ -770,7 +775,9 @@ impl<'config> SubstrateStackSubstate<'config> {
 		self.deletes.insert(address);
 	}
 
-	pub fn set_created(&mut self, address: H160) { self.creates.insert(address); }
+	pub fn set_created(&mut self, address: H160) {
+		self.creates.insert(address);
+	}
 
 	pub fn log(&mut self, address: H160, topics: Vec<H256>, data: Vec<u8>) {
 		self.logs.push(Log {
@@ -1044,7 +1051,9 @@ where
 		self.substate.set_deleted(address)
 	}
 
-	fn set_created(&mut self, address: H160) { self.substate.set_created(address); }
+	fn set_created(&mut self, address: H160) {
+		self.substate.set_created(address);
+	}
 
 	fn set_code(&mut self, address: H160, code: Vec<u8>) {
 		log::debug!(

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -315,10 +315,7 @@ where
 				};
 
 				// Post execution.
-				let pov_gas = core::cmp::min(
-					actual_proof_size.saturating_mul(T::GasLimitPovSizeRatio::get()),
-					gas_limit,
-				);
+				let pov_gas = actual_proof_size.saturating_mul(T::GasLimitPovSizeRatio::get());
 				let used_gas = executor.used_gas();
 				let effective_gas = U256::from(core::cmp::max(
 					core::cmp::max(used_gas, pov_gas),

--- a/primitives/evm/src/lib.rs
+++ b/primitives/evm/src/lib.rs
@@ -79,7 +79,7 @@ pub enum AccessedStorage {
 	AccountStorages((H160, H256)),
 }
 
-#[derive(Clone, Copy, Eq, PartialEq, Debug, Encode, Decode, TypeInfo)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Encode, Decode, Default, TypeInfo)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct WeightInfo {
 	pub ref_time_limit: Option<u64>,


### PR DESCRIPTION
With the new proof size host function we can measure the proof size consumed by a transaction and refund the difference.

We still need to compute the theoretical proof size with our povmeter because we can’t call the hostfunction after each opcode, the idea is to call the host function only twice per eth transaction (once at the beginning and once at the end), then use the measurement to compute the final `pov_gas`.