### PR TITLE
Enable ProofSizeExt when estimating gas and emit ReportRefund when PoV gas is the effective gas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,6 +2441,7 @@ dependencies = [
  "sp-state-machine",
  "sp-storage",
  "sp-timestamp",
+ "sp-trie",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ sc-transaction-pool = { git = "https://github.com/moonbeam-foundation/polkadot-s
 sc-transaction-pool-api = { git = "https://github.com/moonbeam-foundation/polkadot-sdk", branch = "moonbeam-polkadot-stable2407" }
 sc-utils = { git = "https://github.com/moonbeam-foundation/polkadot-sdk", branch = "moonbeam-polkadot-stable2407" }
 # Substrate Primitive
+sp-trie = { git = "https://github.com/moonbeam-foundation/polkadot-sdk", branch = "moonbeam-polkadot-stable2407", default-features = false }
 sp-api = { git = "https://github.com/moonbeam-foundation/polkadot-sdk", branch = "moonbeam-polkadot-stable2407", default-features = false }
 sp-block-builder = { git = "https://github.com/moonbeam-foundation/polkadot-sdk", branch = "moonbeam-polkadot-stable2407", default-features = false }
 sp-blockchain = { git = "https://github.com/moonbeam-foundation/polkadot-sdk", branch = "moonbeam-polkadot-stable2407" }

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -52,6 +52,7 @@ sp-runtime = { workspace = true, features = ["default"] }
 sp-state-machine = { workspace = true, features = ["default"] }
 sp-storage = { workspace = true, features = ["default"] }
 sp-timestamp = { workspace = true, features = ["default"] }
+sp-trie = { workspace = true, features = ["default"] }
 # Frontier
 fc-api = { workspace = true }
 fc-mapping-sync = { workspace = true }

--- a/client/rpc/src/eth/execute.rs
+++ b/client/rpc/src/eth/execute.rs
@@ -365,14 +365,21 @@ where
 						api_version,
 						state_overrides,
 					)?;
+
+					// Enable proof size recording
+					let recorder: sp_trie::recorder::Recorder<HashingFor<B>> = Default::default();
+					let ext = sp_trie::proof_size_extension::ProofSizeExt::new(recorder.clone());
+					let mut exts = Extensions::new();
+					exts.register(ext);
+
 					let params = CallApiAtParams {
 						at: substrate_hash,
 						function: "EthereumRuntimeRPCApi_call",
 						arguments: encoded_params,
 						overlayed_changes: &RefCell::new(overlayed_changes),
 						call_context: CallContext::Offchain,
-						recorder: &None,
-						extensions: &RefCell::new(Extensions::new()),
+						recorder: &Some(recorder),
+						extensions: &RefCell::new(exts),
 					};
 
 					let value = if api_version == 4 {
@@ -500,27 +507,60 @@ where
 					Ok(Bytes(code))
 				} else if api_version == 5 {
 					// Post-london + access list support
-					let access_list = access_list.unwrap_or_default();
-					let info = api
-						.create(
-							substrate_hash,
-							from.unwrap_or_default(),
-							data,
-							value.unwrap_or_default(),
-							gas_limit,
-							max_fee_per_gas,
-							max_priority_fee_per_gas,
-							nonce,
-							false,
-							Some(
-								access_list
-									.into_iter()
-									.map(|item| (item.address, item.storage_keys))
-									.collect(),
-							),
+					let encoded_params = Encode::encode(&(
+						&from.unwrap_or_default(),
+						&data,
+						&value.unwrap_or_default(),
+						&gas_limit,
+						&max_fee_per_gas,
+						&max_priority_fee_per_gas,
+						&nonce,
+						&false,
+						&Some(
+							access_list
+								.unwrap_or_default()
+								.into_iter()
+								.map(|item| (item.address, item.storage_keys))
+								.collect::<Vec<(sp_core::H160, Vec<H256>)>>(),
+						),
+					));
+					let overlayed_changes = self.create_overrides_overlay(
+						substrate_hash,
+						api_version,
+						state_overrides,
+					)?;
+
+					// Enable proof size recording
+					let recorder: sp_trie::recorder::Recorder<HashingFor<B>> = Default::default();
+					let ext = sp_trie::proof_size_extension::ProofSizeExt::new(recorder.clone());
+					let mut exts = Extensions::new();
+					exts.register(ext);
+
+					let params = CallApiAtParams {
+						at: substrate_hash,
+						function: "EthereumRuntimeRPCApi_create",
+						arguments: encoded_params,
+						overlayed_changes: &RefCell::new(overlayed_changes),
+						call_context: CallContext::Offchain,
+						recorder: &Some(recorder),
+						extensions: &RefCell::new(exts),
+					};
+
+					let info =
+						self.client
+							.call_api_at(params)
+							.and_then(|r| {
+								Result::map_err(
+							<Result<ExecutionInfoV2::<H160>, DispatchError> as Decode>::decode(&mut &r[..]),
+							|error| sp_api::ApiError::FailedToDecodeReturnValue {
+								function: "EthereumRuntimeRPCApi_create",
+								error,
+								raw: r
+							},
 						)
-						.map_err(|err| internal_err(format!("runtime error: {err}")))?
-						.map_err(|err| internal_err(format!("execution fatal: {err:?}")))?;
+							})
+							.map_err(|err| internal_err(format!("runtime error: {err}")))?
+							.map_err(|err| internal_err(format!("execution fatal: {err:?}")))?;
 
 					error_on_execution_failure(&info.exit_reason, &[])?;
 
@@ -763,27 +803,56 @@ where
 							(info.exit_reason, info.value, info.used_gas)
 						} else {
 							// Post-london + access list support
-							let access_list = access_list.unwrap_or_default();
-							let info = api.call(
-								substrate_hash,
-								from.unwrap_or_default(),
-								to,
-								data,
-								value.unwrap_or_default(),
-								gas_limit,
-								max_fee_per_gas,
-								max_priority_fee_per_gas,
-								None,
-								estimate_mode,
-								Some(
+							let encoded_params = Encode::encode(&(
+								&from.unwrap_or_default(),
+								&to,
+								&data,
+								&value.unwrap_or_default(),
+								&gas_limit,
+								&max_fee_per_gas,
+								&max_priority_fee_per_gas,
+								&None::<Option<U256>>,
+								&estimate_mode,
+								&Some(
 									access_list
+										.unwrap_or_default()
 										.into_iter()
 										.map(|item| (item.address, item.storage_keys))
-										.collect(),
+										.collect::<Vec<(sp_core::H160, Vec<H256>)>>(),
 								),
-							)
-							.map_err(|err| internal_err(format!("runtime error: {err}")))?
-							.map_err(|err| internal_err(format!("execution fatal: {err:?}")))?;
+							));
+
+							// Proof size recording
+							let recorder: sp_trie::recorder::Recorder<HashingFor<B>> = Default::default();
+							let ext = sp_trie::proof_size_extension::ProofSizeExt::new(recorder.clone());
+							let mut exts = Extensions::new();
+							exts.register(ext);
+
+							let params = CallApiAtParams {
+								at: substrate_hash,
+								function: "EthereumRuntimeRPCApi_call",
+								arguments: encoded_params,
+								overlayed_changes: &RefCell::new(Default::default()),
+								call_context: CallContext::Offchain,
+								recorder: &Some(recorder),
+								extensions: &RefCell::new(exts),
+							};
+
+							let info = self
+								.client
+								.call_api_at(params)
+								.and_then(|r| {
+									Result::map_err(
+										<Result<ExecutionInfoV2::<Vec<u8>>, old_types::OldDispatchError> as Decode>::decode(&mut &r[..]),
+										|error| sp_api::ApiError::FailedToDecodeReturnValue {
+											function: "EthereumRuntimeRPCApi_call",
+											error,
+											raw: r
+										},
+									)
+								})
+								.map_err(|err| internal_err(format!("runtime error: {err}")))?
+								.map_err(|err| internal_err(format!("execution fatal: {err:?}")))?;
 
 							(info.exit_reason, info.value, info.used_gas.effective)
 						}
@@ -851,24 +920,53 @@ where
 							(info.exit_reason, Vec::new(), info.used_gas)
 						} else {
 							// Post-london + access list support
-							let access_list = access_list.unwrap_or_default();
-							let info = api.create(
-								substrate_hash,
-								from.unwrap_or_default(),
-								data,
-								value.unwrap_or_default(),
-								gas_limit,
-								max_fee_per_gas,
-								max_priority_fee_per_gas,
-								None,
-								estimate_mode,
-								Some(
+							let encoded_params = Encode::encode(&(
+								&from.unwrap_or_default(),
+								&data,
+								&value.unwrap_or_default(),
+								&gas_limit,
+								&max_fee_per_gas,
+								&max_priority_fee_per_gas,
+								&None::<Option<U256>>,
+								&estimate_mode,
+								&Some(
 									access_list
+										.unwrap_or_default()
 										.into_iter()
 										.map(|item| (item.address, item.storage_keys))
-										.collect(),
+										.collect::<Vec<(sp_core::H160, Vec<H256>)>>(),
 								),
-							)
+							));
+
+							// Enable proof size recording
+							let recorder: sp_trie::recorder::Recorder<HashingFor<B>> = Default::default();
+							let ext = sp_trie::proof_size_extension::ProofSizeExt::new(recorder.clone());
+							let mut exts = Extensions::new();
+							exts.register(ext);
+
+							let params = CallApiAtParams {
+								at: substrate_hash,
+								function: "EthereumRuntimeRPCApi_create",
+								arguments: encoded_params,
+								overlayed_changes: &RefCell::new(Default::default()),
+								call_context: CallContext::Offchain,
+								recorder: &Some(recorder),
+								extensions: &RefCell::new(exts),
+							};
+
+							let info = self
+							.client
+							.call_api_at(params)
+							.and_then(|r| {
+								Result::map_err(
+									<Result<ExecutionInfoV2::<H160>, DispatchError> as Decode>::decode(&mut &r[..]),
+									|error| sp_api::ApiError::FailedToDecodeReturnValue {
+										function: "EthereumRuntimeRPCApi_create",
+										error,
+										raw: r
+									},
+								)
+							})
 							.map_err(|err| internal_err(format!("runtime error: {err}")))?
 							.map_err(|err| internal_err(format!("execution fatal: {err:?}")))?;
 

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -302,27 +302,71 @@ where
 					None => 0,
 				};
 
-				// Measure actual proof size usage (or get computed proof size)
+				let estimated_proof_size = executor
+					.state()
+					.weight_info()
+					.unwrap_or_default()
+					.proof_size_usage
+					.unwrap_or_default();
+
+				// Obtain the actual proof size usage using the ProofSizeExt host-function or fallback
+				// and use the estimated proof size
 				let actual_proof_size = if let Some(measured_proof_size_after) = get_proof_size() {
-					measured_proof_size_after.saturating_sub(measured_proof_size_before)
+					// actual_proof_size = proof_size_base_cost + proof_size measured with ProofSizeExt
+					let actual_proof_size =
+						proof_size_base_cost.unwrap_or_default().saturating_add(
+							measured_proof_size_after.saturating_sub(measured_proof_size_before),
+						);
+
+					log::trace!(
+						target: "evm",
+						"Proof size computation: (estimated: {}, actual: {})",
+						estimated_proof_size,
+						actual_proof_size
+					);
+
+					// If the proof_size calculated from the host-function gives an higher cost than
+					// the estimated proof_size, we should use the estimated proof_size to compute
+					// the PoV gas.
+					//
+					// TODO: The estimated proof_size should always be an overestimate
+					if actual_proof_size > estimated_proof_size {
+						log::debug!(
+							target: "evm",
+							"Proof size underestimation detected! (estimated: {}, actual: {})",
+							estimated_proof_size,
+							actual_proof_size
+						);
+						estimated_proof_size
+					} else {
+						actual_proof_size
+					}
 				} else {
-					executor
-						.state()
-						.weight_info()
-						.unwrap_or_default()
-						.proof_size_usage
-						.unwrap_or_default()
+					estimated_proof_size
 				};
 
 				// Post execution.
 				let pov_gas = actual_proof_size.saturating_mul(T::GasLimitPovSizeRatio::get());
 				let used_gas = executor.used_gas();
-				let effective_gas = U256::from(core::cmp::max(
-					core::cmp::max(used_gas, pov_gas),
-					storage_gas,
-				));
+				let effective_gas = core::cmp::max(core::cmp::max(used_gas, pov_gas), storage_gas);
 
-				(reason, retv, used_gas, effective_gas)
+				let total_used_gas = executor.state().metadata().gasometer().total_used_gas();
+
+				// Emit refund event if PoV gas is the effective gas,
+				// This is necessary for providing the gas from PoV when using evm-tracing
+				if effective_gas == pov_gas {
+					// The difference will be:
+					// - [- Negative] if extra gas needs to be accounted
+					// - [+ Positive] if less gas needs to be accounted
+					let diff: i64 = (total_used_gas as i64).saturating_sub(effective_gas as i64);
+					let _ = executor
+						.state_mut()
+						.metadata_mut()
+						.gasometer_mut()
+						.record_refund(diff);
+				}
+
+				(reason, retv, used_gas, U256::from(effective_gas))
 			});
 
 		let actual_fee = effective_gas.saturating_mul(total_fee_per_gas);
@@ -1379,6 +1423,7 @@ mod tests {
 			false,
 			None,
 			None,
+			0,
 			|_| {
 				let res = Runner::<Test>::execute(
 					H160::default(),
@@ -1391,6 +1436,7 @@ mod tests {
 					false,
 					None,
 					None,
+					0,
 					|_| (ExitReason::Succeed(ExitSucceed::Stopped), ()),
 				);
 				assert_matches!(
@@ -1423,6 +1469,7 @@ mod tests {
 			false,
 			None,
 			None,
+			0,
 			|_| (ExitReason::Succeed(ExitSucceed::Stopped), ()),
 		);
 		assert!(res.is_ok());

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -350,22 +350,6 @@ where
 				let used_gas = executor.used_gas();
 				let effective_gas = core::cmp::max(core::cmp::max(used_gas, pov_gas), storage_gas);
 
-				let total_used_gas = executor.state().metadata().gasometer().total_used_gas();
-
-				// Emit refund event if PoV gas is the effective gas,
-				// This is necessary for providing the gas from PoV when using evm-tracing
-				if effective_gas == pov_gas {
-					// The difference will be:
-					// - [- Negative] if extra gas needs to be accounted
-					// - [+ Positive] if less gas needs to be accounted
-					let diff: i64 = (total_used_gas as i64).saturating_sub(effective_gas as i64);
-					let _ = executor
-						.state_mut()
-						.metadata_mut()
-						.gasometer_mut()
-						.record_refund(diff);
-				}
-
 				(reason, retv, used_gas, U256::from(effective_gas))
 			});
 

--- a/primitives/evm/src/lib.rs
+++ b/primitives/evm/src/lib.rs
@@ -129,9 +129,6 @@ impl WeightInfo {
 			(self.ref_time_usage, self.ref_time_limit)
 		{
 			let ref_time_usage = self.try_consume(cost, ref_time_limit, ref_time_usage)?;
-			if ref_time_usage > ref_time_limit {
-				return Err(ExitError::OutOfGas);
-			}
 			self.ref_time_usage = Some(ref_time_usage);
 		}
 		Ok(())
@@ -142,10 +139,6 @@ impl WeightInfo {
 			(self.proof_size_usage, self.proof_size_limit)
 		{
 			let proof_size_usage = self.try_consume(cost, proof_size_limit, proof_size_usage)?;
-			if proof_size_usage > proof_size_limit {
-				storage_oog::set_storage_oog();
-				return Err(ExitError::OutOfGas);
-			}
 			self.proof_size_usage = Some(proof_size_usage);
 		}
 		Ok(())


### PR DESCRIPTION
This PR fixes the gas calculation when using tracing or eth_estimateGas/eth_call RPC's.

**Important notes:**

If the estimated proof size is lower than the proof_size obtained from the host-function, the `estimated proof size` is used. We have some underestimations that need to be identified an fixed in a followup pull request.