### PR TITLE
Address POV Underestimations

### DIFF
--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -696,8 +696,9 @@ pub mod pallet {
 
 				let pov = get_proof_size().unwrap_or_default() - pov_before;
 
-				let total_weight = T::DbWeight::get().reads(1)
+				total_weight = total_weight
 					.saturating_add(Weight::from_parts(0, pov))
+					.saturating_add(T::DbWeight::get().reads(1))
 					.saturating_add(account_basic_weight)
 					.saturating_add(min_gas_weight);
 

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -682,21 +682,26 @@ pub mod pallet {
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_initialize(_: BlockNumberFor<T>) -> Weight {
-			let pov_before = get_proof_size();
+			let mut total_weight = Weight::zero();
 
-			let zero_account: H160 = H160::zero();
+			// Do dummy read to populate the pov with the intermediates nodes,
+			// only when proof size recording is enabled.
+			if let Some(pov_before) = get_proof_size() {
+				const ZERO_ACCOUNT: H160 = H160::zero();
 
-			// just a dummy read to populate the pov with the intermediates nodes
-			let _ = AccountCodesMetadata::<T>::get(zero_account.clone());
-			let (_, min_gas_weight) = T::FeeCalculator::min_gas_price();
-			let (_, account_basic_weight) = Pallet::<T>::account_basic(&zero_account);
+				// just a dummy read to populate the pov with the intermediates nodes
+				let _ = AccountCodesMetadata::<T>::get(ZERO_ACCOUNT.clone());
+				let (_, min_gas_weight) = T::FeeCalculator::min_gas_price();
+				let (_, account_basic_weight) = Pallet::<T>::account_basic(&ZERO_ACCOUNT);
 
-			let pov = get_proof_size().unwrap_or_default() - pov_before.unwrap_or_default();
+				let pov = get_proof_size().unwrap_or_default() - pov_before;
 
-			let total_weight = Weight::from_parts(0, pov)
-				+ T::DbWeight::get().reads(1)
-				+ account_basic_weight
-				+ min_gas_weight;
+				let total_weight = T::DbWeight::get().reads(1)
+					.saturating_add(Weight::from_parts(0, pov))
+					.saturating_add(account_basic_weight)
+					.saturating_add(min_gas_weight);
+
+			}
 
 			total_weight
 		}

--- a/primitives/evm/src/lib.rs
+++ b/primitives/evm/src/lib.rs
@@ -130,8 +130,15 @@ impl WeightInfo {
 		if let (Some(ref_time_usage), Some(ref_time_limit)) =
 			(self.ref_time_usage, self.ref_time_limit)
 		{
-			let ref_time_usage = self.try_consume(cost, ref_time_limit, ref_time_usage)?;
-			self.ref_time_usage = Some(ref_time_usage);
+			match self.try_consume(cost, ref_time_limit, ref_time_usage) {
+				Ok(ref_time_usage) => {
+					self.ref_time_usage = Some(ref_time_usage);
+				}
+				Err(e) => {
+					self.ref_time_usage = Some(ref_time_limit);
+					return Err(e);
+				}
+			}
 		}
 		Ok(())
 	}
@@ -140,8 +147,15 @@ impl WeightInfo {
 		if let (Some(proof_size_usage), Some(proof_size_limit)) =
 			(self.proof_size_usage, self.proof_size_limit)
 		{
-			let proof_size_usage = self.try_consume(cost, proof_size_limit, proof_size_usage)?;
-			self.proof_size_usage = Some(proof_size_usage);
+			match self.try_consume(cost, proof_size_limit, proof_size_usage) {
+				Ok(proof_size_usage) => {
+					self.proof_size_usage = Some(proof_size_usage);
+				}
+				Err(e) => {
+					self.proof_size_usage = Some(proof_size_limit);
+					return Err(e);
+				}
+			}
 		}
 		Ok(())
 	}


### PR DESCRIPTION

- Add storage reads in `on_initialize` to cache the intermediary nodes in overlay and pre-account for them in the proof size
    - From testing `AccountCodesMetadata` would result in 900 pov but after running it in the `on_initialize` it droppes down to 72 which is the expected value.
- Add to the base proof size cost for the reading of `AccountCodesMetadata`
- Improve the logs to show the diff of the underestimation and also log the overestimations
- fix `try_record_ref_time_or_fail` and `try_record_proof_size_or_fail` to consume all available limit if we went out of gas, previous behaviour failed before recording the usage. 