### PR TITLE
Implement prevrandao `block_randomness` in pallet-evm

### DIFF
--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -208,6 +208,12 @@ pub mod pallet {
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
 
+		#[pallet::no_default]
+		type RandomnessProvider: frame_support::traits::Randomness<
+			sp_core::H256,
+			BlockNumberFor<Self>,
+		>;
+
 		/// EVM config used in the module.
 		fn config() -> &'static EvmConfig {
 			&CANCUN_CONFIG
@@ -701,7 +707,6 @@ pub mod pallet {
 					.saturating_add(T::DbWeight::get().reads(1))
 					.saturating_add(account_basic_weight)
 					.saturating_add(min_gas_weight);
-
 			}
 
 			total_weight

--- a/frame/evm/src/mock.rs
+++ b/frame/evm/src/mock.rs
@@ -18,7 +18,8 @@
 //! Test mock for unit tests and benchmarking
 
 use frame_support::{derive_impl, parameter_types, weights::Weight};
-use sp_core::{H160, U256};
+use frame_system::pallet_prelude::BlockNumberFor;
+use sp_core::{Hasher, H160, U256};
 
 use crate::{
 	FeeCalculator, IsPrecompileResult, Precompile, PrecompileHandle, PrecompileResult,
@@ -75,6 +76,18 @@ impl crate::Config for Test {
 	type Runner = crate::runner::stack::Runner<Self>;
 	type GasLimitStorageGrowthRatio = GasLimitStorageGrowthRatio;
 	type Timestamp = Timestamp;
+	type RandomnessProvider = RandomnessProvider;
+}
+
+pub struct RandomnessProvider;
+impl frame_support::traits::Randomness<<Test as frame_system::Config>::Hash, BlockNumberFor<Test>>
+	for RandomnessProvider
+{
+	fn random(subject: &[u8]) -> (<Test as frame_system::Config>::Hash, BlockNumberFor<Test>) {
+		let output = <Test as frame_system::Config>::Hashing::hash(subject);
+		let block_number = frame_system::Pallet::<Test>::block_number();
+		(output, block_number)
+	}
 }
 
 pub struct FixedGasPrice;

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -963,7 +963,13 @@ where
 	}
 
 	fn block_randomness(&self) -> Option<H256> {
-		None
+		use frame_support::traits::Randomness;
+		use scale_codec::Encode;
+
+		let current_block = frame_system::Pallet::<T>::block_number();
+		let output = T::RandomnessProvider::random(&current_block.encode()).0;
+
+		Some(output)
 	}
 
 	fn block_gas_limit(&self) -> U256 {

--- a/precompiles/tests-external/lib.rs
+++ b/precompiles/tests-external/lib.rs
@@ -27,7 +27,7 @@ use std::{cell::RefCell, rc::Rc};
 use frame_support::{
 	construct_runtime, derive_impl, parameter_types, traits::Everything, weights::Weight,
 };
-use sp_core::{H160, H256, U256};
+use sp_core::{Hasher, H160, H256, U256};
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 	BuildStorage, Perbill,
@@ -253,6 +253,26 @@ impl pallet_evm::Config for Runtime {
 	type GasLimitStorageGrowthRatio = ();
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
+	type RandomnessProvider = RandomnessProvider;
+}
+
+pub struct RandomnessProvider;
+impl
+	frame_support::traits::Randomness<
+		<Runtime as frame_system::Config>::Hash,
+		frame_system::pallet_prelude::BlockNumberFor<Runtime>,
+	> for RandomnessProvider
+{
+	fn random(
+		subject: &[u8],
+	) -> (
+		<Runtime as frame_system::Config>::Hash,
+		frame_system::pallet_prelude::BlockNumberFor<Runtime>,
+	) {
+		let output = <Runtime as frame_system::Config>::Hashing::hash(subject);
+		let block_number = frame_system::Pallet::<Runtime>::block_number();
+		(output, block_number)
+	}
 }
 
 parameter_types! {

--- a/primitives/evm/src/lib.rs
+++ b/primitives/evm/src/lib.rs
@@ -75,6 +75,8 @@ pub const WRITE_PROOF_SIZE: u64 = 32;
 pub const IS_EMPTY_CHECK_PROOF_SIZE: u64 = 93;
 /// `AccountCodes` key size. 16 (hash) + 20 (key)
 pub const ACCOUNT_CODES_KEY_SIZE: u64 = 36;
+/// System block number.
+pub const SYSTEM_BLOCK_NUMBER_PROOF_SIZE: u64 = 32;
 
 pub enum AccessedStorage {
 	AccountCodes(H160),

--- a/primitives/evm/src/lib.rs
+++ b/primitives/evm/src/lib.rs
@@ -75,8 +75,6 @@ pub const WRITE_PROOF_SIZE: u64 = 32;
 pub const IS_EMPTY_CHECK_PROOF_SIZE: u64 = 93;
 /// `AccountCodes` key size. 16 (hash) + 20 (key)
 pub const ACCOUNT_CODES_KEY_SIZE: u64 = 36;
-/// System block number.
-pub const SYSTEM_BLOCK_NUMBER_PROOF_SIZE: u64 = 32;
 
 pub enum AccessedStorage {
 	AccountCodes(H160),

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -337,6 +337,7 @@ impl<F: FindAuthor<u32>> FindAuthor<H160> for FindAuthorTruncated<F> {
 	}
 }
 
+/// WARNING! THIS IS JUST AN EXAMPLE AND SHOULD NOT BE USED AS A MEANS TO RETRIEVE SECURE RANDOMNESS
 pub struct RandomnessProvider;
 impl
 	frame_support::traits::Randomness<


### PR DESCRIPTION
Get random in `block_randomness` from `RanomnessProvider` implementation passed in as a config to pallet-evm .

This randomness is not necessarily secure since it is generated and returned on the fly.
It is still recommended to use the BABE and local VRF precompiles to request randomness which is returned at a later time.