### PR TITLE
Fix EOA check for precompiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2161,7 +2161,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.41.2"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2409#aeff7f361687b4c6a7fcbe1cf6e4fe5f2aea32b5"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2409#842749e2a0a0319ebbe2a2fbda07b6b749ad6d95"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -2181,7 +2181,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.41.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2409#aeff7f361687b4c6a7fcbe1cf6e4fe5f2aea32b5"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2409#842749e2a0a0319ebbe2a2fbda07b6b749ad6d95"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -2192,7 +2192,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.41.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2409#aeff7f361687b4c6a7fcbe1cf6e4fe5f2aea32b5"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2409#842749e2a0a0319ebbe2a2fbda07b6b749ad6d95"
 dependencies = [
  "environmental",
  "evm-core",
@@ -2203,7 +2203,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.41.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2409#aeff7f361687b4c6a7fcbe1cf6e4fe5f2aea32b5"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2409#842749e2a0a0319ebbe2a2fbda07b6b749ad6d95"
 dependencies = [
  "auto_impl",
  "environmental",

--- a/frame/evm/precompile/dispatch/src/mock.rs
+++ b/frame/evm/precompile/dispatch/src/mock.rs
@@ -217,6 +217,10 @@ impl PrecompileHandle for MockHandle {
 		&self.context
 	}
 
+	fn origin(&self) -> H160 {
+		unimplemented!()
+	}
+
 	fn is_static(&self) -> bool {
 		unimplemented!()
 	}

--- a/frame/evm/test-vector-support/src/lib.rs
+++ b/frame/evm/test-vector-support/src/lib.rs
@@ -111,6 +111,10 @@ impl PrecompileHandle for MockHandle {
 		&self.context
 	}
 
+	fn origin(&self) -> H160 {
+		unimplemented!()
+	}
+
 	fn is_static(&self) -> bool {
 		self.is_static
 	}

--- a/precompiles/src/evm/handle.rs
+++ b/precompiles/src/evm/handle.rs
@@ -177,6 +177,10 @@ mod tests {
 			unimplemented!()
 		}
 
+		fn origin(&self) -> sp_core::H160 {
+			unimplemented!()
+		}
+
 		fn is_static(&self) -> bool {
 			true
 		}

--- a/precompiles/src/precompile_set.rs
+++ b/precompiles/src/precompile_set.rs
@@ -307,7 +307,7 @@ pub enum AddressType {
 	EOA,
 	/// The 5-byte magic constant for a precompile is stored at the address.
 	Precompile,
-	/// Every address that is not a EOA or a Precompile it potentially a Smart Contract.
+	/// Every address that is not a EOA or a Precompile is potentially a Smart Contract.
 	Contract,
 }
 

--- a/precompiles/src/precompile_set.rs
+++ b/precompiles/src/precompile_set.rs
@@ -35,10 +35,6 @@ use impl_trait_for_tuples::impl_for_tuples;
 use pallet_evm::AddressMapping;
 use sp_core::{H160, H256};
 
-// This is the simplest bytecode to revert without returning any data.
-// (PUSH1 0x00 PUSH1 0x00 REVERT)
-pub const REVERT_BYTECODE: [u8; 5] = [0x60, 0x00, 0x60, 0x00, 0xfd];
-
 /// Trait representing checks that can be made on a precompile call.
 /// Types implementing this trait are made to be chained in a tuple.
 ///

--- a/precompiles/src/precompile_set.rs
+++ b/precompiles/src/precompile_set.rs
@@ -320,15 +320,15 @@ pub fn get_address_type<R: pallet_evm::Config>(
 	handle: &mut impl PrecompileHandle,
 	address: H160,
 ) -> Result<AddressType, ExitError> {
-	// Check if address is a precompile
-	if let Ok(true) = is_precompile_or_fail::<R>(address, handle.remaining_gas()) {
-		return Ok(AddressType::Precompile);
-	}
-
 	// It is an Externally Owned Account (EOA)
 	// - When the transaction origin is equal to the address
 	if handle.origin() == address {
 		return Ok(AddressType::EOA);
+	}
+
+	// Check if address is a precompile
+	if let Ok(true) = is_precompile_or_fail::<R>(address, handle.remaining_gas()) {
+		return Ok(AddressType::Precompile);
 	}
 
 	Ok(AddressType::Contract)

--- a/precompiles/src/testing/execution.rs
+++ b/precompiles/src/testing/execution.rs
@@ -72,6 +72,11 @@ impl<'p, P: PrecompileSet> PrecompilesTester<'p, P> {
 		}
 	}
 
+	pub fn with_origin(mut self, origin: impl Into<H160>) -> Self {
+		self.handle.origin = origin.into();
+		self
+	}
+
 	pub fn with_value(mut self, value: impl Into<U256>) -> Self {
 		self.handle.context.apparent_value = value.into();
 		self

--- a/precompiles/src/testing/handle.rs
+++ b/precompiles/src/testing/handle.rs
@@ -77,6 +77,7 @@ pub type SubcallHandle = Box<dyn SubcallTrait>;
 
 /// Mock handle to write tests for precompiles.
 pub struct MockHandle {
+	pub origin: H160,
 	pub gas_limit: u64,
 	pub gas_used: u64,
 	pub logs: Vec<PrettyLog>,
@@ -90,6 +91,7 @@ pub struct MockHandle {
 impl MockHandle {
 	pub fn new(code_address: H160, context: Context) -> Self {
 		Self {
+			origin: context.caller,
 			gas_limit: u64::MAX,
 			gas_used: 0,
 			logs: vec![],
@@ -191,6 +193,10 @@ impl PrecompileHandle for MockHandle {
 	/// Retreive the context in which the precompile is executed.
 	fn context(&self) -> &Context {
 		&self.context
+	}
+
+	fn origin(&self) -> H160 {
+		self.origin
 	}
 
 	/// Is the precompile call is done statically.


### PR DESCRIPTION
Uses the transaction origin in precompile handle to determine if an address is an externally owned account

### Address type heuristics:

- It is a `EOA` when the transaction origin is equal to the address;
- It is a `Precompile` if calling `pallet_evm::Config::PrecompilesValue::get().is_precompile` returns true;
- If neither of the conditions above are true, we assume that an address is a smart-contract.

Also, this is already part of the changes required for supporting https://eips.ethereum.org/EIPS/eip-7702, which is part of the Pectra upgrade.