### PR TITLE
Fix EOA check for precompiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2161,7 +2161,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.41.2"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2409#aeff7f361687b4c6a7fcbe1cf6e4fe5f2aea32b5"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2409#092e1f5a138a2f52cd5d0f009ff1c5ebea1cdc21"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -2181,7 +2181,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.41.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2409#aeff7f361687b4c6a7fcbe1cf6e4fe5f2aea32b5"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2409#092e1f5a138a2f52cd5d0f009ff1c5ebea1cdc21"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -2192,7 +2192,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.41.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2409#aeff7f361687b4c6a7fcbe1cf6e4fe5f2aea32b5"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2409#092e1f5a138a2f52cd5d0f009ff1c5ebea1cdc21"
 dependencies = [
  "environmental",
  "evm-core",
@@ -2203,7 +2203,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.41.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2409#aeff7f361687b4c6a7fcbe1cf6e4fe5f2aea32b5"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2409#092e1f5a138a2f52cd5d0f009ff1c5ebea1cdc21"
 dependencies = [
  "auto_impl",
  "environmental",

--- a/frame/evm/precompile/dispatch/src/mock.rs
+++ b/frame/evm/precompile/dispatch/src/mock.rs
@@ -217,11 +217,19 @@ impl PrecompileHandle for MockHandle {
 		&self.context
 	}
 
+	fn origin(&self) -> H160 {
+		unimplemented!()
+	}
+
 	fn is_static(&self) -> bool {
 		unimplemented!()
 	}
 
 	fn gas_limit(&self) -> Option<u64> {
 		None
+	}
+
+	fn is_contract_being_constructed(&self, _address: H160) -> bool {
+		unimplemented!()
 	}
 }

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -701,7 +701,6 @@ pub mod pallet {
 					.saturating_add(T::DbWeight::get().reads(1))
 					.saturating_add(account_basic_weight)
 					.saturating_add(min_gas_weight);
-
 			}
 
 			total_weight

--- a/frame/evm/test-vector-support/src/lib.rs
+++ b/frame/evm/test-vector-support/src/lib.rs
@@ -46,6 +46,7 @@ pub struct MockHandle {
 	pub context: Context,
 	pub is_static: bool,
 	pub gas_used: u64,
+	pub contracts_being_constructed: Vec<H160>,
 }
 
 impl MockHandle {
@@ -56,6 +57,7 @@ impl MockHandle {
 			context,
 			is_static: false,
 			gas_used: 0,
+			contracts_being_constructed: Default::default(),
 		}
 	}
 }
@@ -111,12 +113,20 @@ impl PrecompileHandle for MockHandle {
 		&self.context
 	}
 
+	fn origin(&self) -> H160 {
+		unimplemented!()
+	}
+
 	fn is_static(&self) -> bool {
 		self.is_static
 	}
 
 	fn gas_limit(&self) -> Option<u64> {
 		self.gas_limit
+	}
+
+	fn is_contract_being_constructed(&self, _address: H160) -> bool {
+		unimplemented!()
 	}
 }
 

--- a/frame/evm/test-vector-support/src/lib.rs
+++ b/frame/evm/test-vector-support/src/lib.rs
@@ -46,7 +46,6 @@ pub struct MockHandle {
 	pub context: Context,
 	pub is_static: bool,
 	pub gas_used: u64,
-	pub contracts_being_constructed: Vec<H160>,
 }
 
 impl MockHandle {
@@ -57,7 +56,6 @@ impl MockHandle {
 			context,
 			is_static: false,
 			gas_used: 0,
-			contracts_being_constructed: Default::default(),
 		}
 	}
 }

--- a/precompiles/src/evm/handle.rs
+++ b/precompiles/src/evm/handle.rs
@@ -177,6 +177,10 @@ mod tests {
 			unimplemented!()
 		}
 
+		fn origin(&self) -> sp_core::H160 {
+			unimplemented!()
+		}
+
 		fn is_static(&self) -> bool {
 			true
 		}
@@ -195,6 +199,10 @@ mod tests {
 		}
 
 		fn refund_external_cost(&mut self, _ref_time: Option<u64>, _proof_size: Option<u64>) {}
+
+		fn is_contract_being_constructed(&self, _address: sp_core::H160) -> bool {
+			unimplemented!()
+		}
 	}
 
 	#[test]

--- a/precompiles/src/precompile_set.rs
+++ b/precompiles/src/precompile_set.rs
@@ -29,7 +29,7 @@ use alloc::{collections::btree_map::BTreeMap, vec, vec::Vec};
 use core::{cell::RefCell, marker::PhantomData, ops::RangeInclusive};
 use fp_evm::{
 	ExitError, IsPrecompileResult, Precompile, PrecompileFailure, PrecompileHandle,
-	PrecompileResult, PrecompileSet,
+	PrecompileResult, PrecompileSet, ACCOUNT_CODES_METADATA_PROOF_SIZE,
 };
 use frame_support::pallet_prelude::Get;
 use impl_trait_for_tuples::impl_for_tuples;
@@ -304,13 +304,11 @@ impl<T: SelectorFilter> PrecompileChecks for CallableByPrecompile<T> {
 #[derive(PartialEq)]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub enum AddressType {
-	/// The code stored at the address is less than 5 bytes, but not well known.
-	Unknown,
 	/// No code is stored at the address, therefore is EOA.
 	EOA,
 	/// The 5-byte magic constant for a precompile is stored at the address.
 	Precompile,
-	/// The code is greater than 5-bytes, potentially a Smart Contract.
+	/// Every address that is not a EOA or a Precompile is potentially a Smart Contract.
 	Contract,
 }
 
@@ -319,9 +317,19 @@ pub fn get_address_type<R: pallet_evm::Config>(
 	handle: &mut impl PrecompileHandle,
 	address: H160,
 ) -> Result<AddressType, ExitError> {
+	// Check if address is a precompile
+	if let Ok(true) = is_precompile_or_fail::<R>(address, handle.remaining_gas()) {
+		return Ok(AddressType::Precompile);
+	}
+
+	// Contracts under-construction don't have code yet
+	if handle.is_contract_being_constructed(address) {
+		return Ok(AddressType::Contract);
+	}
+
 	// AccountCodesMetadata:
 	// Blake2128(16) + H160(20) + CodeMetadata(40)
-	handle.record_db_read::<R>(76)?;
+	handle.record_db_read::<R>(ACCOUNT_CODES_METADATA_PROOF_SIZE as usize)?;
 	let code_len = pallet_evm::Pallet::<R>::account_code_metadata(address).size;
 
 	// 0 => either EOA or precompile without dummy code
@@ -329,29 +337,7 @@ pub fn get_address_type<R: pallet_evm::Config>(
 		return Ok(AddressType::EOA);
 	}
 
-	// dummy code is 5 bytes long, so any other len means it is a contract.
-	if code_len != 5 {
-		return Ok(AddressType::Contract);
-	}
-
-	// check code matches dummy code
-	handle.record_db_read::<R>(code_len as usize)?;
-	let code = pallet_evm::AccountCodes::<R>::get(address);
-	if code == [0x60, 0x00, 0x60, 0x00, 0xfd] {
-		return Ok(AddressType::Precompile);
-	}
-
-	Ok(AddressType::Unknown)
-}
-
-fn is_address_eoa_or_precompile<R: pallet_evm::Config>(
-	handle: &mut impl PrecompileHandle,
-	address: H160,
-) -> Result<bool, ExitError> {
-	match get_address_type::<R>(handle, address)? {
-		AddressType::EOA | AddressType::Precompile => Ok(true),
-		_ => Ok(false),
-	}
+	Ok(AddressType::Contract)
 }
 
 /// Common checks for precompile and precompile sets.
@@ -375,17 +361,21 @@ fn common_checks<R: pallet_evm::Config, C: PrecompileChecks>(
 		u32::from_be_bytes(buffer)
 	});
 
-	// Is this selector callable from a smart contract?
-	let callable_by_smart_contract =
-		C::callable_by_smart_contract(caller, selector).unwrap_or(false);
-	if !callable_by_smart_contract && !is_address_eoa_or_precompile::<R>(handle, caller)? {
-		return Err(revert("Function not callable by smart contracts"));
-	}
+	let caller_address_type = get_address_type::<R>(handle, caller)?;
 
 	// Is this selector callable from a precompile?
 	let callable_by_precompile = C::callable_by_precompile(caller, selector).unwrap_or(false);
-	if !callable_by_precompile && is_precompile_or_fail::<R>(caller, handle.remaining_gas())? {
+	let is_precompile = caller_address_type == AddressType::Precompile;
+	if !callable_by_precompile && is_precompile {
 		return Err(revert("Function not callable by precompiles"));
+	}
+
+	// Is this selector callable from a smart contract?
+	let callable_by_smart_contract =
+		C::callable_by_smart_contract(caller, selector).unwrap_or(false);
+	let is_smart_contract = caller_address_type == AddressType::Contract;
+	if !callable_by_smart_contract && is_smart_contract {
+		return Err(revert("Function not callable by smart contracts"));
 	}
 
 	Ok(())
@@ -463,6 +453,10 @@ impl<'a, H: PrecompileHandle> PrecompileHandle for RestrictiveHandle<'a, H> {
 		self.handle.context()
 	}
 
+	fn origin(&self) -> H160 {
+		self.handle.origin()
+	}
+
 	fn is_static(&self) -> bool {
 		self.handle.is_static()
 	}
@@ -483,6 +477,10 @@ impl<'a, H: PrecompileHandle> PrecompileHandle for RestrictiveHandle<'a, H> {
 
 	fn refund_external_cost(&mut self, ref_time: Option<u64>, proof_size: Option<u64>) {
 		self.handle.refund_external_cost(ref_time, proof_size)
+	}
+
+	fn is_contract_being_constructed(&self, address: H160) -> bool {
+		self.handle.is_contract_being_constructed(address)
 	}
 }
 

--- a/precompiles/src/precompile_set.rs
+++ b/precompiles/src/precompile_set.rs
@@ -332,7 +332,7 @@ pub fn get_address_type<R: pallet_evm::Config>(
 	handle.record_db_read::<R>(ACCOUNT_CODES_METADATA_PROOF_SIZE as usize)?;
 	let code_len = pallet_evm::Pallet::<R>::account_code_metadata(address).size;
 
-	// 0 => either EOA or precompile without dummy code
+	// Having no code at this point means that the address is an EOA
 	if code_len == 0 {
 		return Ok(AddressType::EOA);
 	}

--- a/precompiles/src/testing/handle.rs
+++ b/precompiles/src/testing/handle.rs
@@ -22,6 +22,8 @@ use evm::{ExitRevert, ExitSucceed};
 use fp_evm::{Context, ExitError, ExitReason, Log, PrecompileHandle, Transfer};
 use sp_core::{H160, H256};
 
+use super::Alice;
+
 #[derive(Debug, Clone)]
 pub struct Subcall {
 	pub address: H160,
@@ -213,4 +215,12 @@ impl PrecompileHandle for MockHandle {
 	}
 
 	fn refund_external_cost(&mut self, _ref_time: Option<u64>, _proof_size: Option<u64>) {}
+
+	fn origin(&self) -> H160 {
+		Alice.into()
+	}
+
+	fn is_contract_being_constructed(&self, _address: H160) -> bool {
+		false
+	}
 }

--- a/precompiles/tests-external/lib.rs
+++ b/precompiles/tests-external/lib.rs
@@ -34,7 +34,7 @@ use sp_runtime::{
 };
 // Frontier
 use fp_evm::{ExitReason, ExitRevert, PrecompileFailure, PrecompileHandle};
-use pallet_evm::{EnsureAddressNever, EnsureAddressRoot};
+use pallet_evm::{CodeMetadata, EnsureAddressNever, EnsureAddressRoot};
 use precompile_utils::{
 	precompile_set::*,
 	solidity::{codec::Writer, revert::revert},
@@ -146,7 +146,16 @@ impl MockPrecompile {
 	}
 }
 
-struct MockPrecompileHandle;
+#[derive(Default)]
+struct MockPrecompileHandle {
+	contracts_being_constructed: Vec<H160>,
+}
+impl MockPrecompileHandle {
+	fn with_contracts_being_constructed(mut self, contracts_being_constructed: Vec<H160>) -> Self {
+		self.contracts_being_constructed = contracts_being_constructed;
+		self
+	}
+}
 impl PrecompileHandle for MockPrecompileHandle {
 	fn call(
 		&mut self,
@@ -176,7 +185,7 @@ impl PrecompileHandle for MockPrecompileHandle {
 	fn refund_external_cost(&mut self, _ref_time: Option<u64>, _proof_size: Option<u64>) {}
 
 	fn remaining_gas(&self) -> u64 {
-		unimplemented!()
+		0
 	}
 
 	fn log(&mut self, _: H160, _: Vec<H256>, _: Vec<u8>) -> Result<(), evm::ExitError> {
@@ -195,12 +204,20 @@ impl PrecompileHandle for MockPrecompileHandle {
 		unimplemented!()
 	}
 
+	fn origin(&self) -> H160 {
+		Alice.into()
+	}
+
 	fn is_static(&self) -> bool {
 		true
 	}
 
 	fn gas_limit(&self) -> Option<u64> {
 		unimplemented!()
+	}
+
+	fn is_contract_being_constructed(&self, address: H160) -> bool {
+		self.contracts_being_constructed.contains(&address)
 	}
 }
 
@@ -385,10 +402,12 @@ fn subcalls_works_when_allowed() {
 #[test]
 fn get_address_type_works_for_eoa() {
 	ExtBuilder::default().build().execute_with(|| {
-		let addr = H160::repeat_byte(0x1d);
+		let externally_owned_account: H160 = Alice.into();
+		let mut handle = MockPrecompileHandle::default();
+
 		assert_eq!(
 			AddressType::EOA,
-			get_address_type::<Runtime>(&mut MockPrecompileHandle, addr).expect("OOG")
+			get_address_type::<Runtime>(&mut handle, externally_owned_account).expect("OOG")
 		);
 	})
 }
@@ -396,47 +415,50 @@ fn get_address_type_works_for_eoa() {
 #[test]
 fn get_address_type_works_for_precompile() {
 	ExtBuilder::default().build().execute_with(|| {
-		let addr = H160::repeat_byte(0x1d);
-		pallet_evm::AccountCodes::<Runtime>::insert(addr, vec![0x60, 0x00, 0x60, 0x00, 0xfd]);
-		assert_eq!(
-			AddressType::Precompile,
-			get_address_type::<Runtime>(&mut MockPrecompileHandle, addr).expect("OOG")
-		);
+		let precompiles: Vec<H160> = Precompiles::<Runtime>::used_addresses_h160().collect();
+		// We expect 4 precompiles
+		assert_eq!(precompiles.len(), 4);
+
+		let mut handle = MockPrecompileHandle::default();
+		precompiles.iter().cloned().for_each(|precompile| {
+			assert_eq!(
+				AddressType::Precompile,
+				get_address_type::<Runtime>(&mut handle, precompile).expect("OOG")
+			);
+		});
 	})
 }
 
 #[test]
 fn get_address_type_works_for_smart_contract() {
 	ExtBuilder::default().build().execute_with(|| {
-		let addr = H160::repeat_byte(0x1d);
-
-		// length > 5
-		pallet_evm::AccountCodes::<Runtime>::insert(
-			addr,
-			vec![0x60, 0x00, 0x60, 0x00, 0xfd, 0xff, 0xff],
-		);
-		assert_eq!(
-			AddressType::Contract,
-			get_address_type::<Runtime>(&mut MockPrecompileHandle, addr).expect("OOG")
+		let address = H160::repeat_byte(0x1d);
+		pallet_evm::AccountCodesMetadata::<Runtime>::insert(
+			address,
+			CodeMetadata {
+				hash: Default::default(),
+				size: 1,
+			},
 		);
 
-		// length < 5
-		pallet_evm::AccountCodes::<Runtime>::insert(addr, vec![0x60, 0x00, 0x60]);
+		let mut handle = MockPrecompileHandle::default();
 		assert_eq!(
 			AddressType::Contract,
-			get_address_type::<Runtime>(&mut MockPrecompileHandle, addr).expect("OOG")
+			get_address_type::<Runtime>(&mut handle, address).expect("OOG")
 		);
 	})
 }
 
 #[test]
-fn get_address_type_works_for_unknown() {
+fn get_address_type_works_for_smart_contract_being_constructed() {
 	ExtBuilder::default().build().execute_with(|| {
-		let addr = H160::repeat_byte(0x1d);
-		pallet_evm::AccountCodes::<Runtime>::insert(addr, vec![0x11, 0x00, 0x60, 0x00, 0xfd]);
+		let contract_being_constucted = H160::repeat_byte(0x1d);
+		let mut handle = MockPrecompileHandle::default()
+			.with_contracts_being_constructed(vec![contract_being_constucted]);
+
 		assert_eq!(
-			AddressType::Unknown,
-			get_address_type::<Runtime>(&mut MockPrecompileHandle, addr).expect("OOG")
+			AddressType::Contract,
+			get_address_type::<Runtime>(&mut handle, contract_being_constucted).expect("OOG")
 		);
 	})
 }


### PR DESCRIPTION
Implements a new method on the precompile handler to obtain the addresses of contracts being constructed.

This is necessary because contracts under-construction don't have code, the code will only be added to storage after the init_code is executed.

### Address type heuristics:

- It is a smart-contract if the address is a contract being constructed;
- It is a `Precompile` if calling `pallet_evm::Config::PrecompilesValue::get().is_precompile` returns true;
- It is a `EOA` when the address does not have code;
- If neither of the conditions above are true, we assume that an address is a smart-contract.

Also, this is already part of the changes required for supporting https://eips.ethereum.org/EIPS/eip-7702, which is part of the Pectra upgrade.